### PR TITLE
Fix highlight.js include path

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,14 +18,21 @@
   referrerpolicy="no-referrer"
 />
 
-<!-- Highlight.js support -->
-<link rel="stylesheet" href="/js/highlightjs/styles/github.css" />
-<link rel="stylesheet" href="/js/highlightjs/styles/ssms.css" />
+<!-- Highlight.js support via CDN -->
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/github.min.css"
+  integrity="sha512-Sb9r8AtvXtH5PVYw89RqFfnVDZrh9CfH6iKHrzSOWZfBzpPeekKh1VrAURr2RaxqQD0CIyUL5fP4bwdOHjShNw=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
 
-<script src="/js/highlightjs/highlight.min.js"></script>
-<script src="/js/highlightjs/languages/plaintext.min.js"></script>
-<script src="/js/highlightjs/languages/powershell.min.js"></script>
-<script src="/js/highlightjs/languages/tsql.min.js"></script>
+<script
+  src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"
+  integrity="sha512-0rAt6KvlkmjN+W8sELpAo0P5NdVs4KJIp4jOSAmhpN6wX6Z1GDZCBoBPuiGNsq4CPGK/c/pX9nuSUXGKmzME2g=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+></script>
 
 <script>hljs.highlightAll();</script>
 


### PR DESCRIPTION
## Summary
- call highlight.js from a CDN instead of missing local assets

## Testing
- `ls js 2>&1 | head`