### PR TITLE
Remove unused highlight.js CDN

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ highlighter: rouge
 
 kramdown:
   syntax_highlighter_opts:
-    disable: true
+    disable: false
 
 plugins:
   - jekyll-feed

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,23 +18,7 @@
   referrerpolicy="no-referrer"
 />
 
-<!-- Highlight.js support via CDN -->
-<link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/github.min.css"
-  integrity="sha512-Sb9r8AtvXtH5PVYw89RqFfnVDZrh9CfH6iKHrzSOWZfBzpPeekKh1VrAURr2RaxqQD0CIyUL5fP4bwdOHjShNw=="
-  crossorigin="anonymous"
-  referrerpolicy="no-referrer"
-/>
-
-<script
-  src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"
-  integrity="sha512-0rAt6KvlkmjN+W8sELpAo0P5NdVs4KJIp4jOSAmhpN6wX6Z1GDZCBoBPuiGNsq4CPGK/c/pX9nuSUXGKmzME2g=="
-  crossorigin="anonymous"
-  referrerpolicy="no-referrer"
-></script>
-
-<script>hljs.highlightAll();</script>
+<!-- Removed Highlight.js as the assets were not present locally -->
 
 <!-- Finally, load your override LAST -->
 <link rel="stylesheet" href="/css/override.css" />


### PR DESCRIPTION
## Summary
- remove highlight.js `<link>` and `<script>` tags from the HTML head
- enable Rouge highlighter so code blocks render correctly without highlight.js

## Testing
- `ruby -v`