### PR TITLE
Fix Jekyll build with empty categories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+      - name: Build site
+        run: bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins
+
+gem "webrick", "~> 1.7"
+
+gem "tzinfo-data", platforms: [:mswin, :mingw, :jruby]

--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
+  - vendor
 
 paginate: 5
 paginate_path: "/page:num"

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ title: Home
 <section>
   <h2>My Journey So Far</h2>
   <ul>
-    {% assign journey_posts = site.categories["My Journey So Far"] | sort: "date" %}
+    {% assign journey_posts = site.categories["My Journey So Far"] | default: [] | sort: "date" %}
     {% for post in journey_posts %}
       <li>
         <a href="{{ post.url }}">{{ post.title }}</a>
@@ -47,7 +47,7 @@ title: Home
 <section>
   <h2>Machine Learning Deep-Dives</h2>
   <ul>
-    {% assign ml_posts = site.categories["Machine Learning Deep-Dives"] | sort: "date" %}
+    {% assign ml_posts = site.categories["Machine Learning Deep-Dives"] | default: [] | sort: "date" %}
     {% for post in ml_posts %}
       <li>
         <a href="{{ post.url }}">{{ post.title }}</a>


### PR DESCRIPTION
## Summary
- ignore the vendor directory during builds
- avoid nil errors when categories are empty

## Testing
- `bundle exec jekyll build` *(fails: `bundle: command not found`)*