### PR TITLE
Fix journey page order

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,13 +32,20 @@ title: Home
 <!-- Section for My Journey So Far -->
 <section>
   <h2>My Journey So Far</h2>
+  {% assign journey_posts = site.categories["My Journey So Far"] | sort: "date" %}
+  {% assign full_post = journey_posts | where_exp: "p", "p.title contains 'Full'" | first %}
+  <h3>
+    <a href="{{ full_post.url }}">Full version</a>
+    <small>— {{ full_post.date | date: "%b %d, %Y" }}</small>
+  </h3>
   <ul>
-    {% assign journey_posts = site.categories["My Journey So Far"] | sort: "date" %}
     {% for post in journey_posts %}
+      {% unless post.url == full_post.url %}
       <li>
         <a href="{{ post.url }}">{{ post.title }}</a>
         <small>— {{ post.date | date: "%b %d, %Y" }}</small>
       </li>
+      {% endunless %}
     {% endfor %}
   </ul>
 </section>


### PR DESCRIPTION
## Summary
- show a single **Full version** link at the top of the "My Journey So Far" section
- indent the individual parts underneath so they're grouped

## Testing
- `jekyll build` *(fails: command not found)*