### PR TITLE
Fix grad school link text

### DIFF
--- a/_posts/2025-02-04-grad-school-at-mines.md
+++ b/_posts/2025-02-04-grad-school-at-mines.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "grad school at mine"
+title: "Grad school at Mines"
 date: 2025-02-04 00:00:00 -0500
 categories: ["My Journey So Far"]
 ---

--- a/_posts/2025-02-04-grad-school-at-mines.md
+++ b/_posts/2025-02-04-grad-school-at-mines.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "My Journey So Far - Grad School at Mines"
+title: "grad school at mine"
 date: 2025-02-04 00:00:00 -0500
 categories: ["My Journey So Far"]
 ---


### PR DESCRIPTION
## Summary
- change `_posts/2025-02-04-grad-school-at-mines.md` title to `grad school at mine`
- revert `index.html` to use post titles directly

## Testing
- `jekyll build` *(fails: command not found)*