### PR TITLE
Rename full journey blog post

### DIFF
--- a/_posts/2025-02-09-my-journey-so-far-full.md
+++ b/_posts/2025-02-09-my-journey-so-far-full.md
@@ -1,11 +1,11 @@
 ---
 layout: post
-title: "My Journey So Far - Full"
+title: "My Journey So Far - The Full Story"
 date: 2025-02-09 00:00:00 -0500
 categories: ["My Journey So Far"]
 ---
 
-# My Journey So Far...
+# My Journey So Far - The Full Story
 
 ## Introduction
 I gave [this](https://theinterviewportal.com/2024/01/21/perception-roboticist-interview/) interview back in 2023, where I sat down with Shyam from the Interview Portal and answered some questions about how I landed my role as a robotics engineer focused on perception. However, reflecting on that interview, I realize it's overly focused on the wins. In reality, there were many losses that led to those wins. Here are some additional details that provide a fuller picture of my journey so far...

--- a/index.html
+++ b/index.html
@@ -38,14 +38,14 @@ title: Home
       {% if journey_posts %}
         {% assign journey_posts = journey_posts | sort: "date" %}
       {% endif %}
-      {% assign full_post = journey_posts | where: "title", "My Journey So Far - Full" | first %}
+      {% assign full_post = journey_posts | where: "title", "My Journey So Far - The Full Story" | first %}
       {% if full_post %}
         <li>
-          <a href="{{ full_post.url }}">My Journey So Far</a>
+          <a href="{{ full_post.url }}">My Journey So Far - The Full Story</a>
           <small>— {{ full_post.date | date: "%b %d, %Y" }}</small>
           <ul>
             {% for post in journey_posts %}
-              {% unless post.title == "My Journey So Far - Full" %}
+              {% unless post.title == "My Journey So Far - The Full Story" %}
                 <li>
                   <a href="{{ post.url }}">{{ post.title }}</a>
                   <small>— {{ post.date | date: "%b %d, %Y" }}</small>


### PR DESCRIPTION
## Summary
- rename the full Journey blog post to "My Journey So Far - The Full Story"
- adjust index.html to use new title when linking the full post

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `jekyll build` *(fails: command not found)*