### PR TITLE
Persist music across site

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -92,44 +92,6 @@
         </li>
       </ul>
     </div>
-    <script>
-      const musicButton = document.getElementById('music-button');
-      const musicPlayer = document.getElementById('music-player');
-      const spotifyOption = document.getElementById('choose-spotify');
-      const youtubeOption = document.getElementById('choose-youtube');
-      const togglePlayerBtn = document.getElementById('toggle-music-player');
-      const musicIframe = document.getElementById('music-iframe');
-
-      musicButton.addEventListener('click', () => {
-        if (musicPlayer.style.display === 'none') {
-          musicPlayer.style.display = 'block';
-        } else {
-          musicPlayer.style.display = 'none';
-        }
-      });
-
-      spotifyOption.addEventListener('click', () => {
-        musicIframe.src =
-          'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
-      });
-
-      youtubeOption.addEventListener('click', () => {
-        musicIframe.src = 'https://www.youtube.com/embed/kGuGH_UvvxA';
-      });
-
-      togglePlayerBtn.addEventListener('click', () => {
-        if (musicIframe.style.display === 'none') {
-          musicIframe.style.display = 'block';
-          spotifyOption.style.display = 'inline-block';
-          youtubeOption.style.display = 'inline-block';
-          togglePlayerBtn.textContent = 'Minimize';
-        } else {
-          musicIframe.style.display = 'none';
-          spotifyOption.style.display = 'none';
-          youtubeOption.style.display = 'none';
-          togglePlayerBtn.textContent = 'Expand';
-        }
-      });
-    </script>
+    <script src="/assets/js/music.js"></script>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -74,43 +74,7 @@
         window.location.href = '/';
       });
 
-      const musicButton = document.getElementById('music-button');
-      const musicPlayer = document.getElementById('music-player');
-      const spotifyOption = document.getElementById('choose-spotify');
-      const youtubeOption = document.getElementById('choose-youtube');
-      const togglePlayerBtn = document.getElementById('toggle-music-player');
-      const musicIframe = document.getElementById('music-iframe');
-
-      musicButton.addEventListener('click', () => {
-        if (musicPlayer.style.display === 'none') {
-          musicPlayer.style.display = 'block';
-        } else {
-          musicPlayer.style.display = 'none';
-        }
-      });
-
-      spotifyOption.addEventListener('click', () => {
-        musicIframe.src =
-          'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
-      });
-
-      youtubeOption.addEventListener('click', () => {
-        musicIframe.src = 'https://www.youtube.com/embed/kGuGH_UvvxA';
-      });
-
-      togglePlayerBtn.addEventListener('click', () => {
-        if (musicIframe.style.display === 'none') {
-          musicIframe.style.display = 'block';
-          spotifyOption.style.display = 'inline-block';
-          youtubeOption.style.display = 'inline-block';
-          togglePlayerBtn.textContent = 'Minimize';
-        } else {
-          musicIframe.style.display = 'none';
-          spotifyOption.style.display = 'none';
-          youtubeOption.style.display = 'none';
-          togglePlayerBtn.textContent = 'Expand';
-        }
-      });
     </script>
+    <script src="/assets/js/music.js"></script>
   </body>
 </html>

--- a/assets/js/music.js
+++ b/assets/js/music.js
@@ -1,0 +1,67 @@
+const MUSIC_VISIBLE_KEY = 'musicPlayerVisible';
+const MUSIC_SRC_KEY = 'musicPlayerSrc';
+const MUSIC_MINIMIZED_KEY = 'musicPlayerMinimized';
+
+function initMusicPlayer() {
+  const musicButton = document.getElementById('music-button');
+  const musicPlayer = document.getElementById('music-player');
+  const spotifyOption = document.getElementById('choose-spotify');
+  const youtubeOption = document.getElementById('choose-youtube');
+  const togglePlayerBtn = document.getElementById('toggle-music-player');
+  const musicIframe = document.getElementById('music-iframe');
+
+  // Restore state from localStorage
+  if (localStorage.getItem(MUSIC_VISIBLE_KEY) === 'true') {
+    musicPlayer.style.display = 'block';
+  }
+
+  const savedSrc = localStorage.getItem(MUSIC_SRC_KEY);
+  if (savedSrc) {
+    musicIframe.src = savedSrc;
+  }
+
+  if (localStorage.getItem(MUSIC_MINIMIZED_KEY) === 'true') {
+    musicIframe.style.display = 'none';
+    spotifyOption.style.display = 'none';
+    youtubeOption.style.display = 'none';
+    togglePlayerBtn.textContent = 'Expand';
+  }
+
+  musicButton.addEventListener('click', () => {
+    if (musicPlayer.style.display === 'none') {
+      musicPlayer.style.display = 'block';
+      localStorage.setItem(MUSIC_VISIBLE_KEY, 'true');
+    } else {
+      musicPlayer.style.display = 'none';
+      localStorage.setItem(MUSIC_VISIBLE_KEY, 'false');
+    }
+  });
+
+  spotifyOption.addEventListener('click', () => {
+    musicIframe.src = 'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
+    localStorage.setItem(MUSIC_SRC_KEY, musicIframe.src);
+  });
+
+  youtubeOption.addEventListener('click', () => {
+    musicIframe.src = 'https://www.youtube.com/embed/kGuGH_UvvxA';
+    localStorage.setItem(MUSIC_SRC_KEY, musicIframe.src);
+  });
+
+  togglePlayerBtn.addEventListener('click', () => {
+    if (musicIframe.style.display === 'none') {
+      musicIframe.style.display = 'block';
+      spotifyOption.style.display = 'inline-block';
+      youtubeOption.style.display = 'inline-block';
+      togglePlayerBtn.textContent = 'Minimize';
+      localStorage.setItem(MUSIC_MINIMIZED_KEY, 'false');
+    } else {
+      musicIframe.style.display = 'none';
+      spotifyOption.style.display = 'none';
+      youtubeOption.style.display = 'none';
+      togglePlayerBtn.textContent = 'Expand';
+      localStorage.setItem(MUSIC_MINIMIZED_KEY, 'true');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initMusicPlayer);


### PR DESCRIPTION
## Summary
- add `assets/js/music.js` to persist music preferences in `localStorage`
- include new script in the home and post layouts

## Testing
- `jekyll build` *(fails: command not found)*