### PR TITLE
Fix music button accessibility

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,7 +16,7 @@
     <button
       type="button"
       id="music-button"
-      class="small-rounded-button home-music-button"
+      class="small-rounded-button"
     >
       Play some music while browsing...
     </button>

--- a/css/override.css
+++ b/css/override.css
@@ -60,8 +60,9 @@ body {
 }
 
 #music-button {
-  top: 10px;
-  right: 230px;
+  position: fixed;
+  bottom: 120px;
+  left: 20px;
   width: auto;
   max-width: 200px;
   height: auto;
@@ -79,12 +80,6 @@ body {
   box-shadow: 0 6px 8px rgba(0, 0, 0, 0.4);
 }
 
-#music-button.home-music-button {
-  position: fixed;
-  top: auto;
-  bottom: 180px;
-  right: 20px;
-}
 
 .music-choice {
   margin-right: 4px;


### PR DESCRIPTION
## Summary
- move the music button to the bottom left so it does not overlap the contact panel
- use the same position for all pages

## Testing
- `jekyll build` *(fails: command not found)*