### PR TITLE
Add persistent music player

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -20,26 +20,6 @@
     >
       Play some music while browsing...
     </button>
-    <div
-      id="music-player"
-      style="display:none; position:fixed; bottom:20px; left:20px; z-index:1000;"
-    >
-      <div style="margin-bottom:4px; text-align:center;">
-        <button id="choose-spotify" class="music-choice">Spotify</button>
-        <button id="choose-youtube" class="music-choice">YouTube</button>
-        <button id="close-music-player" class="music-choice">Close</button>
-        <button id="toggle-music-player" class="music-choice">Minimize</button>
-      </div>
-      <iframe
-        id="music-iframe"
-        style="border-radius:12px"
-        src="https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0"
-        width="250"
-        height="80"
-        frameborder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-      ></iframe>
-    </div>
     <!-- MAIN CONTENT in a semi-transparent container -->
     <div
       style="
@@ -93,6 +73,6 @@
         </li>
       </ul>
     </div>
-    <script src="/assets/js/music.js"></script>
+    <script src="/assets/js/music-launcher.js"></script>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,26 +20,6 @@
     <button type="button" id="music-button" class="small-rounded-button">
       Play some music while browsing...
     </button>
-    <div
-      id="music-player"
-      style="display:none; position:fixed; bottom:20px; left:20px; z-index:1000;"
-    >
-      <div style="margin-bottom:4px; text-align:center;">
-        <button id="choose-spotify" class="music-choice">Spotify</button>
-        <button id="choose-youtube" class="music-choice">YouTube</button>
-        <button id="close-music-player" class="music-choice">Close</button>
-        <button id="toggle-music-player" class="music-choice">Minimize</button>
-      </div>
-      <iframe
-        id="music-iframe"
-        style="border-radius:12px"
-        src="https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0"
-        width="250"
-        height="80"
-        frameborder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-      ></iframe>
-    </div>
 
     <main class="page-content" style="max-width:800px; margin:2rem auto;">
       {{ content }}
@@ -76,6 +56,6 @@
       });
 
     </script>
-    <script src="/assets/js/music.js"></script>
-  </body>
-</html>
+      <script src="/assets/js/music-launcher.js"></script>
+    </body>
+  </html>

--- a/assets/js/music-launcher.js
+++ b/assets/js/music-launcher.js
@@ -1,0 +1,12 @@
+function initMusicLauncher() {
+  const musicButton = document.getElementById('music-button');
+  if (!musicButton) return;
+  musicButton.addEventListener('click', () => {
+    const playerWindow = window.open('/music.html', 'MusicPlayer', 'width=320,height=200');
+    if (playerWindow) {
+      playerWindow.focus();
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initMusicLauncher);

--- a/assets/js/music.js
+++ b/assets/js/music.js
@@ -1,24 +1,12 @@
-const MUSIC_VISIBLE_KEY = 'musicPlayerVisible';
 const MUSIC_SRC_KEY = 'musicPlayerSrc';
 const MUSIC_MINIMIZED_KEY = 'musicPlayerMinimized';
 
 function initMusicPlayer() {
-  const musicButton = document.getElementById('music-button');
-  const musicPlayer = document.getElementById('music-player');
   const spotifyOption = document.getElementById('choose-spotify');
   const youtubeOption = document.getElementById('choose-youtube');
   const togglePlayerBtn = document.getElementById('toggle-music-player');
   const closePlayerBtn = document.getElementById('close-music-player');
   const musicIframe = document.getElementById('music-iframe');
-
-  // Restore state from localStorage
-  if (localStorage.getItem(MUSIC_VISIBLE_KEY) === 'true') {
-    musicPlayer.style.display = 'block';
-    musicButton.style.display = 'none';
-  } else {
-    musicPlayer.style.display = 'none';
-    musicButton.style.display = 'block';
-  }
 
   const savedSrc = localStorage.getItem(MUSIC_SRC_KEY);
   if (savedSrc) {
@@ -31,18 +19,6 @@ function initMusicPlayer() {
     youtubeOption.style.display = 'none';
     togglePlayerBtn.textContent = 'Expand';
   }
-
-  musicButton.addEventListener('click', () => {
-    musicPlayer.style.display = 'block';
-    musicButton.style.display = 'none';
-    localStorage.setItem(MUSIC_VISIBLE_KEY, 'true');
-  });
-
-  closePlayerBtn.addEventListener('click', () => {
-    musicPlayer.style.display = 'none';
-    musicButton.style.display = 'block';
-    localStorage.setItem(MUSIC_VISIBLE_KEY, 'false');
-  });
 
   spotifyOption.addEventListener('click', () => {
     musicIframe.src = 'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
@@ -68,6 +44,10 @@ function initMusicPlayer() {
       togglePlayerBtn.textContent = 'Expand';
       localStorage.setItem(MUSIC_MINIMIZED_KEY, 'true');
     }
+  });
+
+  closePlayerBtn.addEventListener('click', () => {
+    window.close();
   });
 }
 

--- a/music.html
+++ b/music.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Music Player</title>
+    <link rel="stylesheet" href="/css/override.css">
+  </head>
+  <body style="background:#000;color:#fff;font-family:sans-serif;">
+    <div id="music-player" style="padding:10px;text-align:center;">
+      <div style="margin-bottom:4px;">
+        <button id="choose-spotify" class="music-choice">Spotify</button>
+        <button id="choose-youtube" class="music-choice">YouTube</button>
+        <button id="close-music-player" class="music-choice">Close</button>
+        <button id="toggle-music-player" class="music-choice">Minimize</button>
+      </div>
+      <iframe
+        id="music-iframe"
+        style="border-radius:12px"
+        src="https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0"
+        width="250"
+        height="80"
+        frameborder="0"
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture">
+      </iframe>
+    </div>
+    <script src="/assets/js/music.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create popup music player page and JS launcher
- drop inline music player markup from layouts
- hook up new popup via `music-launcher.js`
- keep existing player controls in `music.js`

## Testing
- `jekyll build` *(fails: `jekyll: command not found`)*
- `bundle exec jekyll build` *(fails: `bundle: command not found`)*