### PR TITLE
Improve dark mode table colors

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -4,11 +4,17 @@
 :root {
   --background-color: #ffffff;
   --text-color: #000000;
+  --table-border-color: #cccccc;
+  --table-header-bg: #f5f5f5;
+  --table-row-bg-even: #fafafa;
 }
 
 :root[data-theme="dark"] {
   --background-color: #111111;
   --text-color: #dddddd;
+  --table-border-color: #444444;
+  --table-header-bg: #222222;
+  --table-row-bg-even: #2a2a2a;
 }
 
 body {
@@ -163,7 +169,30 @@ a:visited {
 }
 
 /* ------------------------------------------------------
-   6) RESPONSIVE ADJUSTMENTS
+   6) TABLE STYLING
+   ------------------------------------------------------ */
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th,
+td {
+  border: 1px solid var(--table-border-color);
+  padding: 8px;
+}
+
+th {
+  background-color: var(--table-header-bg);
+}
+
+tr:nth-child(even) td {
+  background-color: var(--table-row-bg-even);
+}
+
+/* ------------------------------------------------------
+   7) RESPONSIVE ADJUSTMENTS
    ------------------------------------------------------ */
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add table color variables for dark and light themes
- style table elements so they read well in dark mode

## Testing
- `jekyll build` *(fails: command not found)*