### PR TITLE
[Fix] Improve music popup widget

### DIFF
--- a/assets/js/music-launcher.js
+++ b/assets/js/music-launcher.js
@@ -2,7 +2,7 @@ function initMusicLauncher() {
   const musicButton = document.getElementById('music-button');
   if (!musicButton) return;
   musicButton.addEventListener('click', () => {
-    const playerWindow = window.open('/music.html', 'MusicPlayer', 'width=320,height=200');
+    const playerWindow = window.open('/music.html', 'MusicPlayer', 'width=360,height=220');
     if (playerWindow) {
       playerWindow.focus();
     }

--- a/assets/js/music.js
+++ b/assets/js/music.js
@@ -1,3 +1,5 @@
+const SPOTIFY_SRC = 'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
+const YOUTUBE_SRC = 'https://www.youtube.com/embed/videoseries?list=PLFgquLnL59alCl_2TQvOiD5Vgm1hCaGSI';
 const MUSIC_SRC_KEY = 'musicPlayerSrc';
 const MUSIC_MINIMIZED_KEY = 'musicPlayerMinimized';
 
@@ -9,9 +11,7 @@ function initMusicPlayer() {
   const musicIframe = document.getElementById('music-iframe');
 
   const savedSrc = localStorage.getItem(MUSIC_SRC_KEY);
-  if (savedSrc) {
-    musicIframe.src = savedSrc;
-  }
+  musicIframe.src = savedSrc || SPOTIFY_SRC;
 
   if (localStorage.getItem(MUSIC_MINIMIZED_KEY) === 'true') {
     musicIframe.style.display = 'none';
@@ -21,13 +21,13 @@ function initMusicPlayer() {
   }
 
   spotifyOption.addEventListener('click', () => {
-    musicIframe.src = 'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
-    localStorage.setItem(MUSIC_SRC_KEY, musicIframe.src);
+    musicIframe.src = SPOTIFY_SRC;
+    localStorage.setItem(MUSIC_SRC_KEY, SPOTIFY_SRC);
   });
 
   youtubeOption.addEventListener('click', () => {
-    musicIframe.src = 'https://www.youtube.com/embed/kGuGH_UvvxA';
-    localStorage.setItem(MUSIC_SRC_KEY, musicIframe.src);
+    musicIframe.src = YOUTUBE_SRC;
+    localStorage.setItem(MUSIC_SRC_KEY, YOUTUBE_SRC);
   });
 
   togglePlayerBtn.addEventListener('click', () => {

--- a/css/override.css
+++ b/css/override.css
@@ -86,20 +86,30 @@ body {
   box-shadow: 0 6px 8px rgba(0, 0, 0, 0.4);
 }
 
+#music-widget {
+  background-color: #222;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+  padding: 8px;
+}
+
+.music-controls {
+  margin-bottom: 6px;
+}
+
 
 .music-choice {
   margin-right: 4px;
   padding: 4px 8px;
-  font-size: 12px;
+  background: linear-gradient(135deg, #4b0082, #e100ff);
   border: none;
   border-radius: 4px;
-  background-color: #333;
   color: #fff;
   cursor: pointer;
 }
 
 .music-choice:hover {
-  background-color: #555;
+  opacity: 0.8;
 }
 
 /* ------------------------------------------------------

--- a/music.html
+++ b/music.html
@@ -5,23 +5,17 @@
     <title>Music Player</title>
     <link rel="stylesheet" href="/css/override.css">
   </head>
-  <body style="background:#000;color:#fff;font-family:sans-serif;">
-    <div id="music-player" style="padding:10px;text-align:center;">
-      <div style="margin-bottom:4px;">
+  <body style="background:#1e1e1e;color:#eee;font-family:sans-serif;margin:0;">
+    <div id="music-widget" style="text-align:center;padding:8px;">
+      <div class="music-controls" style="margin-bottom:6px;">
         <button id="choose-spotify" class="music-choice">Spotify</button>
         <button id="choose-youtube" class="music-choice">YouTube</button>
-        <button id="close-music-player" class="music-choice">Close</button>
         <button id="toggle-music-player" class="music-choice">Minimize</button>
+        <button id="close-music-player" class="music-choice">Close</button>
       </div>
-      <iframe
-        id="music-iframe"
-        style="border-radius:12px"
-        src="https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0"
-        width="250"
-        height="80"
-        frameborder="0"
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture">
-      </iframe>
+      <iframe id="music-iframe" width="300" height="80" frameborder="0"
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+        style="border-radius:6px"></iframe>
     </div>
     <script src="/assets/js/music.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- redesign music popup to be smaller and detached
- support Spotify and YouTube playlists
- style music widget with gradients

## Testing Done
- `jekyll build`
