### PR TITLE
[Fix] Improve dark table theme

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -10,11 +10,12 @@
 }
 
 :root[data-theme="dark"] {
-  --background-color: #111111;
-  --text-color: #dddddd;
-  --table-border-color: #444444;
-  --table-header-bg: #222222;
-  --table-row-bg-even: #2a2a2a;
+  /* Use a dark gray background rather than pure black */
+  --background-color: #2b2b2b;
+  --text-color: #ffffff;
+  --table-border-color: #555555;
+  --table-header-bg: #3a3a3a;
+  --table-row-bg-even: #444444;
 }
 
 body {


### PR DESCRIPTION
## Summary
- lighten dark mode backgrounds to dark gray
- use white text and alternating gray rows for tables

## Testing Done
- `jekyll build`
