### PR TITLE
[Fix] Update paper headings

### DIFF
--- a/_posts/2013-12-01-playing-atari-with-dqn.md
+++ b/_posts/2013-12-01-playing-atari-with-dqn.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Paper Short: Playing Atari with Deep Reinforcement Learning"
+title: "Playing Atari with Deep Reinforcement Learning"
 date: 2013-12-01 00:00:00 -0500
 categories: ["Paper Shorts"]
 ---

--- a/_posts/2014-04-01-auto-encoding-variational-bayes.md
+++ b/_posts/2014-04-01-auto-encoding-variational-bayes.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "Paper Short: Auto-Encoding Variational Bayes"
+title: "Auto-Encoding Variational Bayes"
 date: 2014-04-01 00:00:00 -0400
 categories: ["Paper Shorts"]
 ---

--- a/index.html
+++ b/index.html
@@ -85,10 +85,10 @@ title: Home
    </details>
  </section>
 
-<!-- Section for Paper Shorts -->
+<!-- Section for Paper Summaries -->
 <section>
   <details>
-    <summary><h2>Paper Shorts</h2></summary>
+    <summary><h2>Paper Summaries</h2></summary>
     <ul>
       {% assign paper_posts = site.categories["Paper Shorts"] %}
       {% if paper_posts %}


### PR DESCRIPTION
## Summary
- drop `Paper Short` prefix from post titles
- show `Paper Summaries` section on the home page

## Testing Done
- `jekyll build`
