### PR TITLE
[Fix] Adjust dark table styling

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -13,9 +13,9 @@
   /* Use a dark gray background rather than pure black */
   --background-color: #2b2b2b;
   --text-color: #ffffff;
-  --table-border-color: #555555;
-  --table-header-bg: #3a3a3a;
-  --table-row-bg-even: #444444;
+  --table-border-color: #ffffff;
+  --table-header-bg: #333333;
+  --table-row-bg-even: #2b2b2b;
 }
 
 body {
@@ -203,12 +203,14 @@ a:visited {
 table {
   border-collapse: collapse;
   width: 100%;
+  color: var(--text-color);
 }
 
 th,
 td {
   border: 1px solid var(--table-border-color);
   padding: 8px;
+  color: var(--text-color);
 }
 
 th {


### PR DESCRIPTION
## Summary
- tweak CSS variables for table styling in dark mode
- inherit white text and white borders for tables

## Testing Done
- `jekyll build`
