### PR TITLE
[Fix] Add paper summaries landing page

### DIFF
--- a/_posts/2013-12-01-playing-atari-with-dqn.md
+++ b/_posts/2013-12-01-playing-atari-with-dqn.md
@@ -3,6 +3,7 @@ layout: post
 title: "Playing Atari with Deep Reinforcement Learning"
 date: 2013-12-01 00:00:00 -0500
 categories: ["Paper Shorts"]
+field: Reinforcement Learning
 ---
 
 ## 2013 – Playing Atari with Deep Reinforcement Learning

--- a/_posts/2014-04-01-auto-encoding-variational-bayes.md
+++ b/_posts/2014-04-01-auto-encoding-variational-bayes.md
@@ -3,6 +3,7 @@ layout: post
 title: "Auto-Encoding Variational Bayes"
 date: 2014-04-01 00:00:00 -0400
 categories: ["Paper Shorts"]
+field: Variational Inference
 ---
 
 ## 2014 – Auto-Encoding Variational Bayes

--- a/_posts/2014-06-01-generative-adversarial-networks.md
+++ b/_posts/2014-06-01-generative-adversarial-networks.md
@@ -3,6 +3,7 @@ layout: post
 title: "Generative Adversarial Networks"
 date: 2014-06-01 00:00:00 -0400
 categories: ["Paper Shorts"]
+field: Generative Models
 ---
 
 ## 2014 – Generative Adversarial Networks

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@ title: Home
           </li>
         {% endfor %}
       {% endif %}
+      <li><a href="/paper_summaries.html">Organize by year or field</a></li>
     </ul>
   </details>
 </section>

--- a/paper_summaries.md
+++ b/paper_summaries.md
@@ -1,0 +1,45 @@
+---
+layout: page
+title: Paper Summaries
+---
+
+<details>
+  <summary><h2>Organize by Year</h2></summary>
+  {% assign paper_posts = site.categories["Paper Shorts"] %}
+  {% if paper_posts %}
+    {% assign paper_posts = paper_posts | sort: "date" %}
+    {% assign posts_by_year = paper_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+    {% for year in posts_by_year %}
+      <h3>{{ year.name }}</h3>
+      <ul>
+        {% for post in year.items %}
+          <li>
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            <small>— {{ post.date | date: "%b %d, %Y" }}</small>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
+  {% endif %}
+</details>
+
+<details>
+  <summary><h2>Organize by Field</h2></summary>
+  {% assign paper_posts = site.categories["Paper Shorts"] %}
+  {% if paper_posts %}
+    {% assign paper_posts = paper_posts | sort: "date" %}
+    {% assign posts_by_field = paper_posts | group_by: "field" %}
+    {% for field in posts_by_field %}
+      <h3>{{ field.name }}</h3>
+      <ul>
+        {% for post in field.items %}
+          <li>
+            <a href="{{ post.url }}">{{ post.title }}</a>
+            <small>— {{ post.date | date: "%b %d, %Y" }}</small>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
+  {% endif %}
+</details>
+


### PR DESCRIPTION
## Summary
- add custom fields to paper posts
- create `paper_summaries.md` to group papers by year or field
- link new page from home page

## Testing Done
- `jekyll build`
