### PR TITLE
[Fix] Remove minimize button from music widget

### DIFF
--- a/assets/js/music.js
+++ b/assets/js/music.js
@@ -1,24 +1,16 @@
 const SPOTIFY_SRC = 'https://open.spotify.com/embed/playlist/4RHYceSp9R1bHyL0dDqTuQ?utm_source=generator&theme=0';
 const YOUTUBE_SRC = 'https://www.youtube.com/embed/videoseries?list=PLFgquLnL59alCl_2TQvOiD5Vgm1hCaGSI';
 const MUSIC_SRC_KEY = 'musicPlayerSrc';
-const MUSIC_MINIMIZED_KEY = 'musicPlayerMinimized';
 
 function initMusicPlayer() {
   const spotifyOption = document.getElementById('choose-spotify');
   const youtubeOption = document.getElementById('choose-youtube');
-  const togglePlayerBtn = document.getElementById('toggle-music-player');
   const closePlayerBtn = document.getElementById('close-music-player');
   const musicIframe = document.getElementById('music-iframe');
 
   const savedSrc = localStorage.getItem(MUSIC_SRC_KEY);
   musicIframe.src = savedSrc || SPOTIFY_SRC;
 
-  if (localStorage.getItem(MUSIC_MINIMIZED_KEY) === 'true') {
-    musicIframe.style.display = 'none';
-    spotifyOption.style.display = 'none';
-    youtubeOption.style.display = 'none';
-    togglePlayerBtn.textContent = 'Expand';
-  }
 
   spotifyOption.addEventListener('click', () => {
     musicIframe.src = SPOTIFY_SRC;
@@ -30,21 +22,6 @@ function initMusicPlayer() {
     localStorage.setItem(MUSIC_SRC_KEY, YOUTUBE_SRC);
   });
 
-  togglePlayerBtn.addEventListener('click', () => {
-    if (musicIframe.style.display === 'none') {
-      musicIframe.style.display = 'block';
-      spotifyOption.style.display = 'inline-block';
-      youtubeOption.style.display = 'inline-block';
-      togglePlayerBtn.textContent = 'Minimize';
-      localStorage.setItem(MUSIC_MINIMIZED_KEY, 'false');
-    } else {
-      musicIframe.style.display = 'none';
-      spotifyOption.style.display = 'none';
-      youtubeOption.style.display = 'none';
-      togglePlayerBtn.textContent = 'Expand';
-      localStorage.setItem(MUSIC_MINIMIZED_KEY, 'true');
-    }
-  });
 
   closePlayerBtn.addEventListener('click', () => {
     if (window.parent && window.parent !== window) {

--- a/music.html
+++ b/music.html
@@ -10,7 +10,6 @@
       <div class="music-controls" style="margin-bottom:6px;">
         <button id="choose-spotify" class="music-choice">Spotify</button>
         <button id="choose-youtube" class="music-choice">YouTube</button>
-        <button id="toggle-music-player" class="music-choice">Minimize</button>
         <button id="close-music-player" class="music-choice">Close</button>
       </div>
       <iframe id="music-iframe" width="300" height="80" frameborder="0"


### PR DESCRIPTION
## Summary
- drop the minimize/expand button
- simplify `music.js` to just switch sources and close the overlay

## Testing Done
- `jekyll build`
