### PR TITLE
[Fix] Unify table header color

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -228,7 +228,8 @@ td {
 }
 
 th {
-  background-color: var(--table-header-bg);
+  background-color: var(--background-color);
+  font-weight: bold;
 }
 
 tr:nth-child(even) td {


### PR DESCRIPTION
## Summary
- keep table header background consistent with page
- add bold text styling for table headers

## Testing Done
- `jekyll build`
