### PR TITLE
[Fix] Split paper summaries pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,17 +90,8 @@ title: Home
   <details>
     <summary><h2>Paper Summaries</h2></summary>
     <ul>
-      {% assign paper_posts = site.categories["Paper Shorts"] %}
-      {% if paper_posts %}
-        {% assign paper_posts = paper_posts | sort: "date" %}
-        {% for post in paper_posts %}
-          <li>
-            <a href="{{ post.url }}">{{ post.title }}</a>
-            <small>— {{ post.date | date: "%b %d, %Y" }}</small>
-          </li>
-        {% endfor %}
-      {% endif %}
-      <li><a href="/paper_summaries.html">Organize by year or field</a></li>
+      <li><a href="/paper_summaries_year.html">Organized by Year</a></li>
+      <li><a href="/paper_summaries_field.html">Organized by Field</a></li>
     </ul>
   </details>
 </section>

--- a/paper_summaries.md
+++ b/paper_summaries.md
@@ -3,43 +3,9 @@ layout: page
 title: Paper Summaries
 ---
 
-<details>
-  <summary><h2>Organize by Year</h2></summary>
-  {% assign paper_posts = site.categories["Paper Shorts"] %}
-  {% if paper_posts %}
-    {% assign paper_posts = paper_posts | sort: "date" %}
-    {% assign posts_by_year = paper_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
-    {% for year in posts_by_year %}
-      <h3>{{ year.name }}</h3>
-      <ul>
-        {% for post in year.items %}
-          <li>
-            <a href="{{ post.url }}">{{ post.title }}</a>
-            <small>— {{ post.date | date: "%b %d, %Y" }}</small>
-          </li>
-        {% endfor %}
-      </ul>
-    {% endfor %}
-  {% endif %}
-</details>
+<ul>
+  <li><a href="/paper_summaries_year.html">Paper Summaries by Year</a></li>
+  <li><a href="/paper_summaries_field.html">Paper Summaries by Field</a></li>
+</ul>
 
-<details>
-  <summary><h2>Organize by Field</h2></summary>
-  {% assign paper_posts = site.categories["Paper Shorts"] %}
-  {% if paper_posts %}
-    {% assign paper_posts = paper_posts | sort: "date" %}
-    {% assign posts_by_field = paper_posts | group_by: "field" %}
-    {% for field in posts_by_field %}
-      <h3>{{ field.name }}</h3>
-      <ul>
-        {% for post in field.items %}
-          <li>
-            <a href="{{ post.url }}">{{ post.title }}</a>
-            <small>— {{ post.date | date: "%b %d, %Y" }}</small>
-          </li>
-        {% endfor %}
-      </ul>
-    {% endfor %}
-  {% endif %}
-</details>
 

--- a/paper_summaries_field.md
+++ b/paper_summaries_field.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Paper Summaries by Field
+---
+
+{% assign paper_posts = site.categories["Paper Shorts"] %}
+{% if paper_posts %}
+  {% assign paper_posts = paper_posts | sort: "date" %}
+  {% assign posts_by_field = paper_posts | group_by: "field" %}
+  {% for field in posts_by_field %}
+  <h2>{{ field.name }}</h2>
+  <ul>
+    {% for post in field.items %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a>
+      <small>— {{ post.date | date: "%b %d, %Y" }}</small>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endfor %}
+{% endif %}
+

--- a/paper_summaries_year.md
+++ b/paper_summaries_year.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Paper Summaries by Year
+---
+
+{% assign paper_posts = site.categories["Paper Shorts"] %}
+{% if paper_posts %}
+  {% assign paper_posts = paper_posts | sort: "date" %}
+  {% assign posts_by_year = paper_posts | group_by_exp: "post", "post.date | date: '%Y'" %}
+  {% for year in posts_by_year %}
+  <h2>{{ year.name }}</h2>
+  <ul>
+    {% for post in year.items %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a>
+      <small>— {{ post.date | date: "%b %d, %Y" }}</small>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endfor %}
+{% endif %}
+


### PR DESCRIPTION
## Summary
- add dedicated pages for paper summaries by year and by field
- update existing landing page to link to the new pages
- simplify index links to only reference the two new pages

## Testing Done
- `jekyll build`