### PR TITLE
[Fix] Open music player in popup

### DIFF
--- a/assets/js/music-launcher.js
+++ b/assets/js/music-launcher.js
@@ -2,28 +2,8 @@ function initMusicLauncher() {
   const musicButton = document.getElementById('music-button');
   if (!musicButton) return;
 
-  function showOverlay() {
-    let overlay = document.getElementById('music-overlay');
-    if (!overlay) {
-      overlay = document.createElement('div');
-      overlay.id = 'music-overlay';
-      overlay.innerHTML =
-        '<iframe src="/music.html" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>';
-      document.body.appendChild(overlay);
-    } else {
-      overlay.style.display = 'block';
-    }
-  }
-
-  musicButton.addEventListener('click', showOverlay);
-
-  window.addEventListener('message', (event) => {
-    if (event.data === 'close-music-overlay') {
-      const overlay = document.getElementById('music-overlay');
-      if (overlay) {
-        overlay.style.display = 'none';
-      }
-    }
+  musicButton.addEventListener('click', () => {
+    window.open('/music.html', 'music-player', 'width=360,height=220');
   });
 }
 


### PR DESCRIPTION
## Summary
- keep music playing across navigation by opening `music.html` in a popup

## Testing Done
- `jekyll build`
