### PR TITLE
[Fix] Align table headers with table bg

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -228,7 +228,7 @@ td {
 }
 
 th {
-  background-color: var(--background-color);
+  background-color: var(--table-header-bg);
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- align table header background with other rows

## Testing Done
- `jekyll build`
