### PR TITLE
[Fix] Add paper diagrams

### DIFF
--- a/_posts/2014-09-01-sequence-to-sequence-learning-with-neural-networks.md
+++ b/_posts/2014-09-01-sequence-to-sequence-learning-with-neural-networks.md
@@ -15,6 +15,8 @@ field: Natural Language Processing
 **Project page / blog:** [Google Research Blog – "A neural network for machine translation"](https://research.googleblog.com/2014/12/a-neural-network-for-machine-translation.html)
 
 **Conference:** NeurIPS 2014
+![Seq2Seq Architecture](/assets/images/seq2seq.png)
+
 
 **Summary (abstract in plain English):**  
 The authors propose an end-to-end encoder–decoder approach for mapping a source sequence to a target sequence. A multi-layer LSTM encodes the input into a single vector, and a second LSTM decodes that vector to produce the output one token at a time. Trained solely on parallel text, a 4-layer model achieved 34.8 BLEU on WMT’14 English→French, beating a strong phrase-based SMT baseline. Using an ensemble or reranking pushed BLEU to 36.5.

--- a/_posts/2017-06-01-attention-is-all-you-need.md
+++ b/_posts/2017-06-01-attention-is-all-you-need.md
@@ -16,6 +16,8 @@ field: Natural Language Processing
 overview](https://ai.googleblog.com/2017/08/transformer-novel-neural-network.html)
 
 **Conference:** NeurIPS 2017
+![Transformer Architecture](/assets/images/attention.png)
+
 
 **Abstract in a nutshell:** The Transformer removes recurrence and convolutions, relying solely on 
 attention to join an encoder and decoder. This allows full parallelisation in training and 

--- a/_posts/2019-06-01-bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.md
+++ b/_posts/2019-06-01-bert-pre-training-of-deep-bidirectional-transformers-for-language-understanding.md
@@ -15,6 +15,8 @@ field: Natural Language Processing
 **Project page / blog:** [Google AI Blog – "Open Sourcing BERT"](https://ai.googleblog.com/2018/11/open-sourcing-bert-state-of-art-pre.html)
 
 **Conference:** NAACL 2019
+![BERT Model](/assets/images/bert.png)
+
 
 **Summary (abstract in plain English):**
 BERT is a Transformer encoder stack with 12 layers (BERT-base) or 24 layers (BERT-large) pre-trained on the BooksCorpus and English Wikipedia (3.3B tokens).


### PR DESCRIPTION
## Summary
- embed architecture diagrams in NLP paper summaries

## Testing Done
- `jekyll build`