### PR TITLE
[Fix] Add dark editor code theme

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,3 +25,6 @@
 {% if page.editor_theme %}
 <link rel="stylesheet" href="/css/editor-theme.css" />
 {% endif %}
+{% if page.layout == "editor" %}
+<link rel="stylesheet" href="{{ "/assets/css/editor-code.css" | relative_url }}">
+{% endif %}

--- a/_plugins/editor_wrap.rb
+++ b/_plugins/editor_wrap.rb
@@ -1,0 +1,8 @@
+# Auto-add .editor-block to every Rouge output for editor layout
+Jekyll::Hooks.register :documents, :post_render do |doc|
+  next unless doc.data["layout"] == "editor"
+  doc.output.gsub!(
+    %r{<div class="highlight">},
+    '<div class="highlight editor-block">'
+  )
+end

--- a/assets/css/editor-code.css
+++ b/assets/css/editor-code.css
@@ -1,0 +1,79 @@
+/* ====================  EDITOR SHELL  ==================== */
+:root {
+  --editor-bg:            #202334;   /* main background */
+  --editor-panel:         #1b1e2c;   /* side gutter  */
+  --editor-guide:         #2d3148;   /* indent guide */
+  --editor-fg:            #abb2bf;   /* default text */
+  --editor-comment:       #5c6370;
+  --editor-keyword:       #c678dd;
+  --editor-fn:            #61afef;
+  --editor-string:        #98c379;
+  --editor-number:        #d19a66;
+  --editor-boolean:       #e06c75;
+  --editor-cursor:        #528bff;
+}
+
+/* Wrap every highlight.js / Rouge block in a scoped class so other
+   pages (personal layout) can keep Minima’s defaults.  */
+.editor-block {
+  position: relative;
+  background: var(--editor-bg);
+  color: var(--editor-fg);
+  overflow: auto;
+  padding: 1.25rem 0 1.25rem 4.5rem;   /* room for gutter */
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+/* ===== 1.a  GUTTER (optional line numbers) ===== */
+.editor-block::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4rem;               /* gutter width */
+  height: 100%;
+  background: var(--editor-panel);
+  border-right: 1px solid rgba(255,255,255,.04);
+}
+
+/* ===== 1.b  INDENT GUIDES ===== */
+.editor-block {
+  background-image:
+    repeating-linear-gradient(
+      to right,
+      transparent 0,
+      transparent calc(4ch - 1px),
+      var(--editor-guide) calc(4ch - 1px),
+      var(--editor-guide) calc(4ch)   /* one guide every 4ch */
+    );
+  background-clip: content-box;       /* keep guides inside code area */
+}
+
+/* ====================  SYNTAX  (Rouge + Highlight.js)  ==================== */
+.hljs-comment,  .c      { color: var(--editor-comment); }
+.hljs-quote                 { color: var(--editor-comment); font-style: italic; }
+
+.hljs-keyword,  .k,
+.hljs-selector-tag,
+.hljs-meta    { color: var(--editor-keyword); }
+
+.hljs-string,  .s,
+.hljs-title,   .hljs-section { color: var(--editor-string); }
+
+.hljs-number,  .m      { color: var(--editor-number); }
+
+.hljs-built_in,
+.hljs-builtins,
+.hljs-function,
+.hljs-title.function_ { color: var(--editor-fn); }
+
+.hljs-literal, .hljs-attr { color: var(--editor-boolean); }
+
+/* Cursor effect on hover (pure CSS) */
+.editor-block:hover {
+  outline: 1px solid var(--editor-cursor);
+  outline-offset: -1px;
+}
+


### PR DESCRIPTION
## Summary
- add IDE-style code block CSS
- load the editor style only for editor layout pages
- wrap Rouge output with `.editor-block`

## Testing Done
- `jekyll build`