### PR TITLE
[Fix] Improve theme variables

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,8 +9,8 @@
       background:
         radial-gradient(
           circle at 30% 30%,
-          rgba(0,0,0,.4) 0%,
-          rgba(0,0,0,.8) 70%
+          var(--bg-overlay-start) 0%,
+          var(--bg-overlay-end) 70%
         ),
         url('/assets/images/shootingstar.jpg') center/cover fixed;
       min-height: 100vh;

--- a/css/override.css
+++ b/css/override.css
@@ -4,6 +4,9 @@
 :root {
   --background-color: #ffffff;
   --text-color: #000000;
+  --icon-color: #000000;
+  --bg-overlay-start: rgba(255,255,255,0.4);
+  --bg-overlay-end: rgba(255,255,255,0.8);
   --table-border-color: #cccccc;
   --table-header-bg: #f5f5f5;
   --table-row-bg-even: #fafafa;
@@ -15,12 +18,15 @@
 :root[data-theme="dark"] {
   --background-color: #000000;
   --text-color: #ffff00;
+  --icon-color: #ffff00;
   --table-border-color: #ffff00;
   --table-header-bg: #111111;
   --table-row-bg-even: #000000;
   --image-border-color: #ffff00;
   --code-bg-color: #111111;
   --code-text-color: #ffff00;
+  --bg-overlay-start: rgba(0,0,0,0.4);
+  --bg-overlay-end: rgba(0,0,0,0.8);
 }
 
 html {
@@ -49,6 +55,7 @@ body {
   font-weight: 900;
   content: '\f054';
   margin-right: 0.5em;
+  color: var(--icon-color);
 }
 
 /* ------------------------------------------------------
@@ -89,7 +96,7 @@ code {
   border: none;
   border-radius: 9999px;    /* Fully rounded corners */
   background-color: #f0f0f0;
-  color: #333;
+  color: var(--icon-color);
   cursor: pointer;
   font-size: 14px;
   text-align: center;
@@ -296,6 +303,7 @@ code {
 /* Space between icon and text */
 .link-list li i {
   margin-right: 8px;
+  color: var(--icon-color);
 }
 
 /* ------------------------------------------------------


### PR DESCRIPTION
## Summary
- support light/dark overlay colors on the home background
- use `--icon-color` for icons in lists and buttons

## Testing Done
- `jekyll build`