### PR TITLE
[Fix] Disable home page theme toggle

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   {% include head.html %}
   <body
     style="
@@ -25,9 +25,6 @@
     >
       <i class="fas fa-music"></i>
       Play some music while browsing...
-    </button>
-    <button type="button" id="theme-toggle" class="small-rounded-button">
-      <i class="fas fa-adjust"></i>
     </button>
     <div id="music-bar"></div>
     <!-- MAIN CONTENT in a semi-transparent container -->
@@ -70,17 +67,6 @@
         </li>
       </ul>
     </div>
-  <script>
-    const themeToggle = document.getElementById('theme-toggle');
-    const storedTheme = localStorage.getItem('theme') || 'light';
-    document.documentElement.setAttribute('data-theme', storedTheme);
-    themeToggle.addEventListener('click', () => {
-      const current = document.documentElement.getAttribute('data-theme');
-      const next = current === 'dark' ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem('theme', next);
-    });
-  </script>
   <script src="/assets/js/music-launcher.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- make home page use the dark theme by default
- remove the theme toggle button and script from `home.html`

## Testing Done
- `jekyll build`