### PR TITLE
[Fix] centralise code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Posts use the default layout `post` and are automatically tagged via the configu
 ## Structure
 
 - `_layouts/` – Contains page templates. `home.html` defines the landing page layout with a full-page background and a pinned "Contact Me" panel at the bottom right. `post.html` defines post pages with light/dark theme toggling and an arrow button that returns to the home page.
-- `_includes/` – Partial templates. `head.html` loads Font Awesome icons and Highlight.js for code syntax highlighting. `navlinks.html` and `sharelinks.html` provide previous/next navigation and social-sharing buttons respectively.
+- `_includes/` – Partial templates. `head.html` loads fonts and metadata. Code syntax highlighting is handled globally via `_includes/code-assets.html`; update that file to change the theme or version. `navlinks.html` and `sharelinks.html` provide previous/next navigation and social-sharing buttons respectively.
 - `css/override.css` – Custom styles, including variables for dark/light themes, styling for buttons, and a pinned links panel.
 - `index.html` – Home page content listing posts from two categories ("My Journey So Far" and "ML Deep research reports").
 - `paper_summaries.md` – Landing page for research paper notes, linking to pages organized by year and by field.

--- a/_includes/code-assets.html
+++ b/_includes/code-assets.html
@@ -1,0 +1,6 @@
+<!-- Centralised *once-only* Highlight.js + theme load. Update versions here and
+     every page using the `page` layout will pick it up automatically. -->
+<link rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,7 +35,6 @@
   crossorigin
 />
 
-<!-- Removed Highlight.js as the assets were not present locally -->
 
 <!-- Finally, load your override LAST -->
 <link rel="stylesheet" href="/css/override.css" />

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    {% include head.html %}          {#-- existing meta/SEO/fonts etc. --#}
+    {% include code-assets.html %}   {#-- 1-liner pulls in the code bundle --#}
+  </head>
+
+  <body>
+    <main class="page-content" aria-label="Content">
+      {{ content }}
+    </main>
+  </body>
+</html>

--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -1,0 +1,17 @@
+/* _sass/_code.scss  — the one true place for code-block styling  */
+pre.highlight,
+.code-block {
+  background: #0d1117;   /* dark GitHub theme */
+  color: #c9d1d9;
+  padding: 1rem;
+  border-radius: .5rem;
+  overflow-x: auto;
+  font-size: .9rem;
+  line-height: 1.55;
+}
+
+/* Optional tweaks */
+pre.highlight code,
+.code-block code { background: none; }
+
+/* If you want line numbers later, add them here once. */

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,5 @@
+---
+---
+
+@import "minima";
+@import "code";

--- a/css/override.css
+++ b/css/override.css
@@ -116,54 +116,6 @@ img {
   justify-content: center;
 }
 
-/* ------------------------------------------------------
-   2a) CODE BLOCKS
-   ------------------------------------------------------ */
-pre,
-code {
-  background-color: var(--code-bg-color);
-  color: var(--code-text-color);
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-  font-family: "JetBrains Mono", monospace;
-}
-
-.code-block {
-  background-color: var(--code-bg-color);
-  color: var(--code-text-color);
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
-  font-family: "JetBrains Mono", monospace;
-  overflow-x: auto;
-}
-
-.code-block code {
-  background: none;
-  color: inherit;
-  padding: 0;
-}
-
-/* Rouge-generated code blocks */
-.highlight {
-  background-color: var(--code-bg-color);
-  color: var(--code-text-color);
-  padding: 0.5rem 0.75rem;
-  border-radius: 4px;
-  overflow-x: auto;
-}
-
-.highlight pre {
-  background: none;
-  color: inherit;
-  margin: 0;
-  padding: 0;
-}
-
-.highlight code {
-  background: none;
-  color: inherit;
-  padding: 0;
-}
 
 /* 2) Small rounded button styling */
 .small-rounded-button {


### PR DESCRIPTION
## Summary
- create `code-assets.html` partial for Highlight.js
- rewrite `page.html` layout to include code assets
- clean up `head.html`
- move code-block styles to `_sass/_code.scss`
- add `assets/main.scss` and import code styles
- update README about code highlighting

## Testing Done
- `jekyll build`
