### PR TITLE
[Fix] Add copy buttons to code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Posts use the default layout `post` and are automatically tagged via the configu
 Assets such as images are stored in `assets/images/`.
 PDFs can be added to `assets/pdfs/` and will appear in the ML Deep research reports section.
 Scripts such as the music player live in `assets/js/`.
+`code-block.js` enhances code snippets with line numbers and copy buttons.
 
 ## Getting Started
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -38,4 +38,5 @@
 
 <!-- Finally, load your override LAST -->
 <link rel="stylesheet" href="/css/override.css" />
+<script src="/assets/js/code-block.js"></script>
 

--- a/_sass/minima/_code.scss
+++ b/_sass/minima/_code.scss
@@ -1,0 +1,31 @@
+/* Extended code styles with line numbers and copy button */
+
+pre.highlight {
+  position: relative;
+  counter-reset: line;
+}
+
+pre.highlight code > span {
+  display: block;
+  padding-left: 3rem;
+  position: relative;
+}
+
+pre.highlight code > span::before {
+  counter-increment: line;
+  content: counter(line);
+  position: absolute;
+  left: 0;
+  width: 2.5rem;
+  color: #888888;
+  text-align: right;
+}
+
+pre.highlight .copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}

--- a/assets/js/code-block.js
+++ b/assets/js/code-block.js
@@ -1,0 +1,19 @@
+function initCodeCopy() {
+  document.querySelectorAll('pre.highlight').forEach(pre => {
+    const btn = document.createElement('button');
+    btn.className = 'copy-btn';
+    btn.type = 'button';
+    btn.textContent = 'Copy';
+    pre.appendChild(btn);
+
+    btn.addEventListener('click', () => {
+      const text = pre.innerText;
+      navigator.clipboard.writeText(text).then(() => {
+        btn.textContent = 'Copied!';
+        setTimeout(() => { btn.textContent = 'Copy'; }, 1500);
+      });
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initCodeCopy);

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -2,4 +2,5 @@
 ---
 
 @import "minima";
+@import "minima/code";
 @import "code";


### PR DESCRIPTION
## Summary
- show line numbers and copy buttons for code blocks
- expose code-block.js in the head include
- update README with instructions

## Testing Done
- `jekyll build`