### PR TITLE
[Fix] Update dark mode colors

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -34,15 +34,15 @@
 }
 
 :root[data-theme="dark"] {
-  --background-color: #000000;
-  --text-color: #32cd32;
-  --icon-color: #32cd32;
-  --table-border-color: #32cd32;
+  --background-color: #00005a;
+  --text-color: #f0ead6;
+  --icon-color: #f0ead6;
+  --table-border-color: #f0ead6;
   --table-header-bg: #111111;
-  --table-row-bg-even: #000000;
-  --image-border-color: #32cd32;
+  --table-row-bg-even: #00005a;
+  --image-border-color: #f0ead6;
   --code-bg-color: #111111;
-  --code-text-color: #32cd32;
+  --code-text-color: #f0ead6;
   --music-bg-start: #c026d3;
   --music-bg-end: #7c3aed;
   --music-vibe-start: #e879f9;


### PR DESCRIPTION
Updated dark theme variables to use a dark blue background and eggshell white text for better contrast.

### Testing Done
- `jekyll build`