### PR TITLE
[Fix] Remove ASCII art block

### DIFF
--- a/_posts/2025-04-01-cs336-revision-notes.md
+++ b/_posts/2025-04-01-cs336-revision-notes.md
@@ -26,13 +26,6 @@ Tensor fundamentals, computational efficiency, and key PyTorch concepts.
 7. Xavier (Glorot) Initialisation
 
 ---
-```
-  ____  ____  ___
- / ___||  _ \|_ _|
-| |    | | | || |
-| |___ | |_| || |
- \____||____/|___|
-```
 
 ### 1. Float Types: Which to Use and Why?
 


### PR DESCRIPTION
Removed an unused ASCII art code block from the CS336 revision notes.

### Testing Done
- `jekyll build`
