### PR TITLE
[Fix] Add Python interpreter page

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -418,3 +418,40 @@ tr:nth-child(even) td {
     line-height: 1.2;
   }
 }
+
+/* ------------------------------------------------------
+   8) PYTHON TERMINAL
+   ------------------------------------------------------ */
+.py-terminal {
+  background-color: var(--code-bg-color);
+  padding: 1rem;
+  border-radius: 8px;
+  font-family: monospace;
+}
+
+.py-terminal textarea {
+  width: 100%;
+  height: 150px;
+  background-color: var(--code-bg-color);
+  color: var(--code-text-color);
+  border: 1px solid var(--table-border-color);
+  border-radius: 4px;
+  padding: 0.5rem;
+  font-family: monospace;
+}
+
+.py-terminal button {
+  margin-top: 0.5rem;
+  padding: 0.4rem 0.8rem;
+}
+
+.py-terminal pre {
+  background-color: var(--code-bg-color);
+  color: var(--code-text-color);
+  border: 1px solid var(--table-border-color);
+  border-radius: 4px;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  overflow-x: auto;
+}
+

--- a/python_playground.md
+++ b/python_playground.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: Python Playground
+---
+
+<p>This page provides a simple browser-based Python interpreter powered by Pyodide.</p>
+
+<div class="py-terminal">
+  <textarea id="py-input" placeholder="print('hello, world')"></textarea>
+  <button id="py-run" type="button">Run</button>
+  <pre id="py-output"></pre>
+</div>
+
+<script type="module">
+  import { loadPyodide } from 'https://cdn.jsdelivr.net/pyodide/v0.23.2/full/pyodide.mjs';
+  async function main() {
+    const pyodide = await loadPyodide();
+    document.getElementById('py-run').addEventListener('click', async () => {
+      const code = document.getElementById('py-input').value;
+      let result = '';
+      try {
+        result = await pyodide.runPythonAsync(code);
+      } catch (err) {
+        result = err;
+      }
+      document.getElementById('py-output').textContent = result ?? '';
+    });
+  }
+  main();
+</script>
+
+<p>Use <code>uv</code> locally to install additional packages and create a custom environment before bundling it with Pyodide.</p>
+


### PR DESCRIPTION
## Summary
- add `python_playground.md` with a Pyodide-backed interpreter
- style the interpreter in `override.css`

## Testing Done
- `jekyll build`
