### PR TITLE
[Fix] Toggle icon color by theme

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -12,7 +12,7 @@
       class="small-rounded-button"
       aria-label="Toggle theme"
     >
-      <i class="fas fa-moon"></i>
+      <i class="fas fa-moon moon-icon"></i>
     </button>
     <main class="page-content" aria-label="Content">
       {{ content }}
@@ -31,9 +31,9 @@
 
       function updateToggleIcon() {
         if (html.getAttribute('data-theme') === 'dark') {
-          toggleButton.innerHTML = '<i class="fas fa-sun"></i>';
+          toggleButton.innerHTML = '<i class="fas fa-sun sun-icon"></i>';
         } else {
-          toggleButton.innerHTML = '<i class="fas fa-moon"></i>';
+          toggleButton.innerHTML = '<i class="fas fa-moon moon-icon"></i>';
         }
       }
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@
       class="small-rounded-button"
       aria-label="Toggle theme"
     >
-      <i class="fas fa-moon"></i>
+      <i class="fas fa-moon moon-icon"></i>
     </button>
 
 
@@ -47,9 +47,9 @@
 
     function updateToggleIcon() {
       if (html.getAttribute('data-theme') === 'dark') {
-        toggleButton.innerHTML = '<i class="fas fa-sun"></i>';
+        toggleButton.innerHTML = '<i class="fas fa-sun sun-icon"></i>';
       } else {
-        toggleButton.innerHTML = '<i class="fas fa-moon"></i>';
+        toggleButton.innerHTML = '<i class="fas fa-moon moon-icon"></i>';
       }
     }
 

--- a/css/override.css
+++ b/css/override.css
@@ -455,3 +455,12 @@ tr:nth-child(even) td {
   overflow-x: auto;
 }
 
+/* Icons for the theme toggle button */
+.sun-icon {
+  color: #ffcc00;
+}
+
+.moon-icon {
+  color: #4b5563;
+}
+

--- a/music.html
+++ b/music.html
@@ -13,7 +13,7 @@
       aria-label="Toggle theme"
       style="top:10px; right:10px; position:absolute;"
     >
-      <i class="fas fa-moon"></i>
+      <i class="fas fa-moon moon-icon"></i>
     </button>
     <div id="music-widget">
       <div class="music-controls">
@@ -41,9 +41,9 @@
 
       function updateToggleIcon() {
         if (html.getAttribute('data-theme') === 'dark') {
-          toggleButton.innerHTML = '<i class="fas fa-sun"></i>';
+          toggleButton.innerHTML = '<i class="fas fa-sun sun-icon"></i>';
         } else {
-          toggleButton.innerHTML = '<i class="fas fa-moon"></i>';
+          toggleButton.innerHTML = '<i class="fas fa-moon moon-icon"></i>';
         }
       }
 


### PR DESCRIPTION
## Summary
- color sun and moon icons via new classes
- use the classes on theme toggle buttons
- update JavaScript to swap icons with color

## Testing Done
- `jekyll build`
