### PR TITLE
[Fix] Adjust home page text color

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -14,7 +14,7 @@
         ),
         url('/assets/images/shootingstar.jpg') center/cover fixed;
       min-height: 100vh;
-      color: var(--text-color);
+      color: #f0ead6;
       font-family: sans-serif;
     "
   >


### PR DESCRIPTION
Updated home page layout so text displays in eggshell white.

### Testing Done
- `jekyll build`