### PR TITLE
[Fix] Use default GitHub code theme

### DIFF
--- a/_includes/code-assets.html
+++ b/_includes/code-assets.html
@@ -1,6 +1,8 @@
 <!-- Centralised *once-only* Highlight.js + theme load. Update versions here and
      every page using the `page` layout will pick it up automatically. -->
-<link rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/tokyo-night-dark.min.css">
+<link id="hljs-theme-light" rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+<link id="hljs-theme-dark" rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -23,12 +23,25 @@
       const STORAGE_KEY = 'theme';
       const toggleButton = document.getElementById('theme-toggle');
       const html = document.documentElement;
+      const lightCss = document.getElementById('hljs-theme-light');
+      const darkCss = document.getElementById('hljs-theme-dark');
+
+      function applyHighlightTheme(theme) {
+        if (theme === 'dark') {
+          darkCss.disabled = false;
+          lightCss.disabled = true;
+        } else {
+          darkCss.disabled = true;
+          lightCss.disabled = false;
+        }
+      }
 
       function applySavedTheme() {
         const saved = localStorage.getItem(STORAGE_KEY);
         if (saved === 'light' || saved === 'dark') {
           html.setAttribute('data-theme', saved);
         }
+        applyHighlightTheme(html.getAttribute('data-theme'));
       }
 
       function updateToggleIcon() {
@@ -47,6 +60,7 @@
         html.setAttribute('data-theme', newTheme);
         localStorage.setItem(STORAGE_KEY, newTheme);
         updateToggleIcon();
+        applyHighlightTheme(newTheme);
       });
 
       const homeButton = document.getElementById('home-button');

--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -1,8 +1,6 @@
 /* _sass/_code.scss  — the one true place for code-block styling  */
 pre.highlight,
 .code-block {
-  background: var(--code-bg-color);
-  color: var(--code-text-color);
   padding: 1rem;
   border-radius: .5rem;
   overflow-x: auto;

--- a/css/override.css
+++ b/css/override.css
@@ -11,8 +11,6 @@
   --table-header-bg: #f5f5f5;
   --table-row-bg-even: #fafafa;
   --image-border-color: #000000;
-  --code-bg-color: #f5f5f5;
-  --code-text-color: #000000;
   --panel-bg: rgba(0, 0, 0, 0.3);
   --music-bg-start: #3b82f6;
   --music-bg-end: #0ea5e9;
@@ -28,8 +26,6 @@
   --table-header-bg: #f5f5f5;
   --table-row-bg-even: #fafafa;
   --image-border-color: #000080;
-  --code-bg-color: #f5f5f5;
-  --code-text-color: #000080;
   --panel-bg: rgba(5, 5, 5, 0.3);
 }
 
@@ -41,8 +37,6 @@
   --table-header-bg: #1e1e1e;
   --table-row-bg-even: #181818;
   --image-border-color: #f5f5f5;
-  --code-bg-color: #1a1b26;
-  --code-text-color: #c0caf5;
   --music-bg-start: #c026d3;
   --music-bg-end: #7c3aed;
   --music-vibe-start: #e879f9;
@@ -433,7 +427,6 @@ tr:nth-child(even) td {
    8) PYTHON TERMINAL
    ------------------------------------------------------ */
 .py-terminal {
-  background-color: var(--code-bg-color);
   padding: 1rem;
   border-radius: 8px;
   font-family: monospace;
@@ -442,8 +435,6 @@ tr:nth-child(even) td {
 .py-terminal textarea {
   width: 100%;
   height: 150px;
-  background-color: var(--code-bg-color);
-  color: var(--code-text-color);
   border: 1px solid var(--table-border-color);
   border-radius: 4px;
   padding: 0.5rem;
@@ -457,8 +448,6 @@ tr:nth-child(even) td {
 
 
 .py-terminal pre {
-  background-color: var(--code-bg-color);
-  color: var(--code-text-color);
   border-radius: 4px;
   padding: 0.5rem;
   margin-top: 0.5rem;
@@ -467,8 +456,6 @@ tr:nth-child(even) td {
 
 
 .run-output {
-  background-color: var(--code-bg-color);
-  color: var(--code-text-color);
   border-radius: 4px;
   padding: 0.5rem;
   margin-top: 0.5rem;


### PR DESCRIPTION
## Summary
- load highlight.js GitHub light and dark themes
- toggle highlight theme when switching site theme
- drop custom code block colors

## Testing Done
- `jekyll build`