### PR TITLE
[Fix] Add colab link to lecture notes

### DIFF
--- a/_posts/2025-04-01-cs336-revision-notes.md
+++ b/_posts/2025-04-01-cs336-revision-notes.md
@@ -224,3 +224,6 @@ Glorot assumes `tanh`-like activations and keeps variance constant forward **and
 
 ## Source
 Percy Liang, **CS336 — Large Language Models**, Stanford University, Lecture 2: *Tensor Fundamentals & Computation Efficiency* (Winter 2025).
+
+## Colab notebook
+A Google Colab notebook with the code is available [here](https://colab.research.google.com/drive/1heDkWNo4DDdJn9pXYDFEyUYUHLL3M-qc?usp=sharing).


### PR DESCRIPTION
## Summary
- add a Colab notebook link at the end of Lecture 2 notes

## Testing Done
- `jekyll build`