### PR TITLE
[Fix] Dim dark mode code block colors

### DIFF
--- a/_includes/code-assets.html
+++ b/_includes/code-assets.html
@@ -3,6 +3,6 @@
 <link id="hljs-theme-light" rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
 <link id="hljs-theme-dark" rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark-dimmed.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>

--- a/css/override.css
+++ b/css/override.css
@@ -34,8 +34,8 @@
   --text-color: #f5f5f5;
   --icon-color: #f5f5f5;
   --table-border-color: #f5f5f5;
-  --table-header-bg: #1e1e1e;
-  --table-row-bg-even: #181818;
+  --table-header-bg: #262626;
+  --table-row-bg-even: #202020;
   --image-border-color: #f5f5f5;
   --music-bg-start: #c026d3;
   --music-bg-end: #7c3aed;


### PR DESCRIPTION
## Summary
- switch highlight.js dark theme to GitHub Dark Dimmed
- tone down dark mode table header colors

## Testing Done
- `jekyll build`
