### PR TITLE
[Fix] Add equation box styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Update it in pull requests as new conventions are adopted.
 - Keep lines under 120 characters when possible.
 - End files with a single newline.
 - Write comments as full sentences and end them with a period.
+- Wrap standalone math in `<div class="equation-box">` to use the equation style.
 
 ## Local workflow
 - Run `jekyll build` to verify the site compiles before committing changes that affect the structure or content.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,6 +28,27 @@
   referrerpolicy="no-referrer"
 />
 
+<!-- KaTeX for math rendering -->
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
+  integrity="sha384-CErX1DK4Fk6gXV8zvfuTQDXyP/d9vywgqbiZ9erjRzCQXDpUe1koRaSPjqH9fHYC"
+  crossorigin="anonymous"
+/>
+<script
+  defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
+  integrity="sha384-U2mttSwjISiYDUFVN05oig3NbS1Ry6j8Tz7kRXKuX3sI5Yucs5pT96D65VnDkMur"
+  crossorigin="anonymous"
+></script>
+<script
+  defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
+  integrity="sha384-KAbFlcI74JdCRDM98qNFVmWX5nL6pMBiGjVZ6ljbDSBxJ1FMz7bK2rsque57RZ63"
+  crossorigin="anonymous"
+  onload="renderMathInElement(document.body);"
+></script>
+
 <!-- Variable font preload -->
 <link
   rel="preload"

--- a/css/override.css
+++ b/css/override.css
@@ -16,6 +16,8 @@
   --music-bg-end: #0ea5e9;
   --music-vibe-start: #60a5fa;
   --music-vibe-end: #38bdf8;
+  --equation-bg: #ffffff;
+  --equation-text: #000000;
 }
 
 :root[data-theme="light"] {
@@ -27,6 +29,8 @@
   --table-row-bg-even: #fafafa;
   --image-border-color: #000080;
   --panel-bg: rgba(5, 5, 5, 0.3);
+  --equation-bg: #ffffff;
+  --equation-text: #000000;
 }
 
 :root[data-theme="dark"] {
@@ -44,6 +48,8 @@
   --bg-overlay-start: rgba(0, 0, 0, 0.7);
   --bg-overlay-end: rgba(0, 20, 40, 0.95);
   --panel-bg: rgba(0, 0, 0, 0.3);
+  --equation-bg: #000000;
+  --equation-text: #ffffff;
 }
 
 html {
@@ -445,5 +451,17 @@ tr:nth-child(even) td {
 
 .moon-icon {
   color: #4b5563;
+}
+
+/* ------------------------------------------------------
+   8) EQUATION BOX
+   ------------------------------------------------------ */
+.equation-box {
+  background-color: var(--equation-bg);
+  color: var(--equation-text);
+  border: 1px solid var(--equation-text);
+  padding: 1rem;
+  margin: 1rem 0;
+  overflow-x: auto;
 }
 

--- a/equation_box.md
+++ b/equation_box.md
@@ -1,0 +1,13 @@
+---
+layout: content
+title: Equation Box Demo
+---
+
+This page demonstrates the new equation box styling.
+
+<div class="equation-box">
+$$
+\int_a^b f(x) \, dx = F(b) - F(a)
+$$
+</div>
+


### PR DESCRIPTION
## Summary
- support math rendering with KaTeX
- style `.equation-box` for light and dark themes
- add a demo page using the new equation box
- document the new style guideline

## Testing Done
- `jekyll build`