### PR TITLE
[Fix] Darker code blocks

### DIFF
--- a/_includes/code-assets.html
+++ b/_includes/code-assets.html
@@ -3,6 +3,6 @@
 <link id="hljs-theme-light" rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/tokyo-night-light.min.css">
 <link id="hljs-theme-dark" rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/tokyo-night-dark.min.css">
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark-dimmed.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>

--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -6,6 +6,7 @@ pre.highlight,
   overflow-x: auto;
   font-size: .9rem;
   line-height: 1.55;
+  background-color: #1d1f21;
 }
 
 /* Optional tweaks */


### PR DESCRIPTION
## Summary
- use the `github-dark-dimmed` highlight.js theme
- set a custom dark background for code blocks

## Testing Done
- `jekyll build`
