### PR TITLE
[Fix] Add section index to Journey page

### DIFF
--- a/_posts/2025-02-08-my-journey-so-far-full-story.md
+++ b/_posts/2025-02-08-my-journey-so-far-full-story.md
@@ -5,11 +5,21 @@ date: 2025-02-08 00:00:00 -0500
 categories: ["My Journey So Far"]
 ---
 
+## Index
+- [Introduction](#introduction)
+- [Growing Up](#growing-up)
+- [Undergrad at MIT, Manipal](#undergrad)
+- [Depression](#depression)
+- [Grad school at Mines](#grad-school)
+- [Finding a Job Out of Grad School](#job-hunt)
+- [First Job at DEKA](#first-job)
+- [Zoox](#zoox)
+
 ## Introduction {#introduction}
 
 In 2023, I gave [this interview](https://theinterviewportal.com/2024/01/21/perception-roboticist-interview/) where I primarily discussed how I landed my role as a robotics engineer focused on perception. But looking back, I realized that interview mostly highlighted the wins - and didn’t touch much on the many missteps and setbacks along the way. To give a more balanced view, I want to share some additional reflections on my journey so far, starting from the very beginning.
 
-## Growing Up
+## Growing Up {#growing-up}
 
 I grew up in Jaipur, a city that shaped much of my early life. I lost my father when I was 5, but my mother and sisters made sure I never felt that I was missing anything while growing up, surrounding me with immense love and support. Despite their efforts, I remained quite introverted, finding an escape in video games like DOTA and DOTA 2. In fact, I logged around **16,000** hours and even reached the **#16 rank in India** at one point. It was an obsession that helped me cope with life’s stresses, but over time, I realized that channeling similar dedication into the “real” world could lead to more significant accomplishments. That revelation eventually pulled me out of my shell and motivated me to pursue my dreams in the US.
 


### PR DESCRIPTION
## Summary
Added a table of contents at the top of the "My Journey So Far" post and linked each entry to its section. Also added an anchor to the "Growing Up" heading.

## Testing Done
- `jekyll build`