### PR TITLE
[Fix] Head missing in home layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="light">
-  {% include head.html %}
+  <head>
+    {% include head.html %}
+  </head>
   <body
     style="
       margin: 0;


### PR DESCRIPTION
## Summary
- wrap head includes in `<head>` element in home layout

## Testing Done
- `jekyll build`