### PR TITLE
[Fix] Add local KaTeX assets

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,21 +31,15 @@
 <!-- KaTeX for math rendering -->
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
-  integrity="sha384-CErX1DK4Fk6gXV8zvfuTQDXyP/d9vywgqbiZ9erjRzCQXDpUe1koRaSPjqH9fHYC"
-  crossorigin="anonymous"
-/>
+  href="{{ '/assets/katex/katex.min.css' | relative_url }}"
+/> 
 <script
   defer
-  src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"
-  integrity="sha384-U2mttSwjISiYDUFVN05oig3NbS1Ry6j8Tz7kRXKuX3sI5Yucs5pT96D65VnDkMur"
-  crossorigin="anonymous"
+  src="{{ '/assets/katex/katex.min.js' | relative_url }}"
 ></script>
 <script
   defer
-  src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"
-  integrity="sha384-KAbFlcI74JdCRDM98qNFVmWX5nL6pMBiGjVZ6ljbDSBxJ1FMz7bK2rsque57RZ63"
-  crossorigin="anonymous"
+  src="{{ '/assets/katex/auto-render.min.js' | relative_url }}"
 ></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/assets/katex/auto-render.min.js
+++ b/assets/katex/auto-render.min.js
@@ -1,0 +1,1 @@
+// TODO: Replace with KaTeX 0.16.9 auto-render script for offline usage.

--- a/assets/katex/katex.min.css
+++ b/assets/katex/katex.min.css
@@ -1,0 +1,1 @@
+/* TODO: Replace with KaTeX 0.16.9 stylesheet for offline usage. */

--- a/assets/katex/katex.min.js
+++ b/assets/katex/katex.min.js
@@ -1,0 +1,1 @@
+// TODO: Replace with KaTeX 0.16.9 script for offline usage.


### PR DESCRIPTION
## Summary
- reference local KaTeX files in `head.html`
- add placeholder KaTeX assets to `assets/katex`

## Testing Done
- `jekyll build`
