### PR TITLE
[Fix] KaTeX init timing

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -48,14 +48,16 @@
   crossorigin="anonymous"
 ></script>
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
-    renderMathInElement(document.body, {
-      delimiters: [
-        {left: '$$', right: '$$', display: true},
-        {left: '\\(', right: '\\)', display: false},
-        {left: '\\[', right: '\\]', display: true}
-      ]
-    });
+  window.addEventListener('load', () => {
+    if (typeof renderMathInElement === 'function') {
+      renderMathInElement(document.body, {
+        delimiters: [
+          {left: '$$', right: '$$', display: true},
+          {left: '\\(', right: '\\)', display: false},
+          {left: '\\[', right: '\\]', display: true}
+        ]
+      });
+    }
   });
 </script>
 


### PR DESCRIPTION
## Summary
- ensure KaTeX renders after the scripts load

## Testing Done
- `jekyll build`