### PR TITLE
[Fix] Equation color

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -468,4 +468,8 @@ tr:nth-child(even) td {
   margin: 1rem 0;
   overflow-x: auto;
 }
+.equation-box .katex-display,
+.equation-box .katex {
+  color: var(--equation-text);
+}
 


### PR DESCRIPTION
## Summary
- ensure KaTeX text inherits equation color

## Testing Done
- `jekyll build`
