### PR TITLE
[Fix] Update syntax theme

### DIFF
--- a/_includes/code-assets.html
+++ b/_includes/code-assets.html
@@ -1,8 +1,8 @@
 <!-- Centralised *once-only* Highlight.js + theme load. Update versions here and
      every page using the `page` layout will pick it up automatically. -->
 <link id="hljs-theme-light" rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/tokyo-night-light.min.css">
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
 <link id="hljs-theme-dark" rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark-dimmed.min.css">
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>

--- a/css/override.css
+++ b/css/override.css
@@ -1,6 +1,10 @@
 /* ------------------------------------------------------
    1) BUTTONS
    ------------------------------------------------------ */
+/* Reset global text rendering */
+* {
+  text-rendering: auto;
+}
 :root {
   --background-color: #f8f8f8;
   --text-color: #000080;


### PR DESCRIPTION
## Summary
- reset global text rendering
- use github.css for light mode
- use github-dark.css for dark mode

## Testing Done
- `jekyll build`
