### PR TITLE
[Fix] Simplify theme toggle CSS

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -179,18 +179,6 @@ img {
   height: 100vh; /* Full viewport height; adjusts automatically with background-size: cover */
 }
 
-#theme-toggle {
-  top: 10px;
-  right: 120px;
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  line-height: 48px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 18px;
-}
 
 #home-button {
   top: 10px;
@@ -210,6 +198,9 @@ img {
   height: 48px;
   border-radius: 50%;
   line-height: 48px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding: 0;
   font-size: 24px;
 }


### PR DESCRIPTION
## Summary
- remove duplicate theme-toggle styles
- keep one block with display and alignment properties

## Testing Done
- `jekyll build`
