### PR TITLE
[Fix] Use tokyonight for dark

### DIFF
--- a/_includes/code-assets.html
+++ b/_includes/code-assets.html
@@ -3,6 +3,6 @@
 <link id="hljs-theme-light" rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
 <link id="hljs-theme-dark" rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/tokyo-night-dark.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>

--- a/css/override.css
+++ b/css/override.css
@@ -42,24 +42,24 @@
 }
 
 :root[data-theme="dark"] {
-  --background-color: #0d1117;
-  --text-color: #e6edf3;
-  --icon-color: #e6edf3;
-  --table-border-color: #30363d;
-  --table-header-bg: #161b22;
-  --table-row-bg-even: #0d1117;
-  --image-border-color: #e6edf3;
-  --music-bg-start: #8b5cf6;
-  --music-bg-end: #d946ef;
-  --music-vibe-start: #a855f7;
-  --music-vibe-end: #ec4899;
+  --background-color: #1a1b26;
+  --text-color: #c0caf5;
+  --icon-color: #c0caf5;
+  --table-border-color: #3b4261;
+  --table-header-bg: #1f2335;
+  --table-row-bg-even: #1a1b26;
+  --image-border-color: #c0caf5;
+  --music-bg-start: #7aa2f7;
+  --music-bg-end: #bb9af7;
+  --music-vibe-start: #7dcfff;
+  --music-vibe-end: #f7768e;
   --bg-overlay-start: rgba(0, 0, 0, 0.7);
   --bg-overlay-end: rgba(0, 0, 0, 0.95);
   --panel-bg: rgba(0, 0, 0, 0.3);
-  --equation-bg: #0d1117;
-  --equation-text: #e6edf3;
-  --code-bg: #000000;     
-  --code-text: #e6edf3;
+  --equation-bg: #1a1b26;
+  --equation-text: #c0caf5;
+  --code-bg: #1a1b26;
+  --code-text: #c0caf5;
 }
 
 html {


### PR DESCRIPTION
### Summary
- switch Highlight.js dark theme to Tokyo Night
- tweak dark CSS variables to match the Tokyo Night palette

### Testing Done
- `jekyll build`