### PR TITLE
[Fix] Use Pojoaque highlight theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Posts use the default layout `post` and are automatically tagged via the configu
 ## Structure
 
 - `_layouts/` – Contains page templates. `home.html` defines the landing page layout with a full-page background and a pinned "Contact Me" panel at the bottom right. `post.html` defines post pages with light/dark theme toggling and an arrow button that returns to the home page.
-- `_includes/` – Partial templates. `head.html` loads fonts and metadata. Code syntax highlighting is handled globally via `_includes/code-assets.html`; update that file to change the theme or version. `navlinks.html` and `sharelinks.html` provide previous/next navigation and social-sharing buttons respectively.
+- `_includes/` – Partial templates. `head.html` loads fonts and metadata. Code syntax highlighting is handled globally via `_includes/code-assets.html` (currently using the *Pojoaque* theme); update that file to change the version or theme. `navlinks.html` and `sharelinks.html` provide previous/next navigation and social-sharing buttons respectively.
 - `css/override.css` – Custom styles, including variables for dark/light themes, styling for buttons, and a pinned links panel.
 - `index.html` – Home page content listing posts from two categories ("My Journey So Far" and "ML Deep research reports").
 - `paper_summaries.md` – Landing page for research paper notes, linking to pages organized by year and by field.

--- a/_includes/code-assets.html
+++ b/_includes/code-assets.html
@@ -1,8 +1,8 @@
 <!-- Centralised *once-only* Highlight.js + theme load. Update versions here and
      every page using the `page` layout will pick it up automatically. -->
 <link id="hljs-theme-light" rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/pojoaque.min.css">
 <link id="hljs-theme-dark" rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/tokyo-night-dark.min.css">
+      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/pojoaque.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <script>hljs.highlightAll();</script>


### PR DESCRIPTION
## Summary
- switch highlight.js stylesheets to Pojoaque
- mention Pojoaque in README

## Testing Done
- `jekyll build`
