### PR TITLE
[Fix] Insert images in paper summaries

### DIFF
--- a/_posts/2013-12-01-playing-atari-with-dqn.md
+++ b/_posts/2013-12-01-playing-atari-with-dqn.md
@@ -16,6 +16,8 @@ field: Reinforcement Learning
 
 **Conference:** NIPS Deep Learning Workshop 2013 (expanded Nature version published 2015)
 
+![DQN Agent](/assets/images/DQN Atari Reinforcement Learning Summaries.png)
+
 **Summary (abstract in plain English):** The paper introduces the Deep Q-Network (DQN) — a convolutional neural network that learns, via Q-learning, to map raw Atari-2600 screen pixels directly to action values. Two key stabilisation tricks make deep RL feasible:
 1. **Experience replay:** store transitions and sample them randomly to break temporal correlations.
 2. **Target network:** hold a slowly updated copy of the Q-network to compute stable learning targets.

--- a/_posts/2019-11-01-mastering-atari-go-chess-shogi-muzero.md
+++ b/_posts/2019-11-01-mastering-atari-go-chess-shogi-muzero.md
@@ -16,6 +16,8 @@ field: Reinforcement Learning
 
 **Journal / Conference:** Nature 2020 (pre-print Nov 2019)
 
+![MuZero Architecture](/assets/images/muzero.png)
+
 **Summary of the paper**
 MuZero unifies model-free and model-based reinforcement learning. It learns three networks—representation,
 dynamics and prediction—that act as a latent simulator. The dynamics network rolls the hidden state forward

--- a/_posts/2020-10-01-an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
+++ b/_posts/2020-10-01-an-image-is-worth-16x16-words-transformers-for-image-recognition-at-scale.md
@@ -16,6 +16,8 @@ field: Computer Vision
 
 **Conference:** ICLR 2021
 
+![Vision Transformer](/assets/images/Vision Transformer VIT.png)
+
 **Summary (abstract in plain English):** ViT slices an image into 16×16 patches, flattens them, adds a learnable positional embedding and a [CLS] token, then processes the sequence with a Transformer encoder. When pre-trained on very large datasets and fine-tuned, ViT matches or exceeds leading CNNs while using fewer training FLOPs.
 
 **Novel insights:**

--- a/_posts/2022-03-01-training-language-models-to-follow-instructions-with-human-feedback.md
+++ b/_posts/2022-03-01-training-language-models-to-follow-instructions-with-human-feedback.md
@@ -16,6 +16,8 @@ field: Alignment
 
 **Conference:** NeurIPS 2022 (spotlight)
 
+![RLHF Pipeline](/assets/images/DQN Atari RLHF.png)
+
 **Plain-language abstract**
 Large GPT-3 models were impressive, but they often ignored or misunderstood user instructions. The authors show that reinforcement learning from human feedback (RLHF) can align a language model with user intent. The process involves supervised fine-tuning on human-written demonstrations, training a reward model from ranked outputs, and then policy optimisation with PPO while penalising divergence from the supervised model. Even a 1.3&nbsp;B parameter InstructGPT matches or beats the 175&nbsp;B GPT-3 on real prompts and reduces toxicity and hallucination.
 


### PR DESCRIPTION
## Summary
- embed RL-related images into their respective posts

## Testing Done
- `jekyll build`