### PR TITLE
[Fix] Apply minimalistic dark theme

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -69,6 +69,9 @@
   crossorigin
 />
 
+<!-- Google Fonts for typography -->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@500;700&family=IBM+Plex+Sans:wght@300;400&family=Roboto+Mono:wght@400;500&display=swap" />
+
 
 <!-- Finally, load your override LAST -->
 <link rel="stylesheet" href="/css/override.css" />

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,7 +17,7 @@
         url('/assets/images/shootingstar.jpg') center/cover fixed;
       min-height: 100vh;
       color: #f0ead6;
-      font-family: sans-serif;
+      font-family: "IBM Plex Sans", sans-serif;
     "
   >
     <button

--- a/_posts/2025-04-01-cs336-revision-notes.md
+++ b/_posts/2025-04-01-cs336-revision-notes.md
@@ -16,7 +16,9 @@ a course on large language models taught by Percy Liang at Stanford.
 
 ---
 
-## Quick Overview 
+## Quick Overview
+
+<div class="quick-overview">
 
 1. **Set-up & dtype benchmarking** – install PyTorch with the ultra-fast `uv` installer, sanity-check CUDA, and time core tensor ops across dtypes.
 2. **Numerical formats in practice** – when to reach for `bfloat16`, why `float16` needs loss-scaling, and why FP8 is inference-only (today).
@@ -25,6 +27,8 @@ a course on large language models taught by Percy Liang at Stanford.
 5. **Einops power-moves** – ditch `.view()/.permute()` boilerplate and reshape like a pro.
 6. **Kernel arithmetic cost** – pocket FLOP calculators for GEMM, conv2d, and attention; introduction to Model FLOP Utilisation (MFU).
 7. **Initialisation hygiene** – Glorot vs. He, and when it actually matters.
+
+</div>
 
 ---
 

--- a/css/override.css
+++ b/css/override.css
@@ -32,19 +32,22 @@
 }
 
 :root[data-theme="dark"] {
-  --background-color: #1a1b26;
-  --text-color: #c0caf5;
-  --icon-color: #c0caf5;
-  --image-border-color: #c0caf5;
+  --background-color: #121212;
+  --background-secondary: #1E1E1E;
+  --text-color: #E0E0E0;
+  --text-secondary-color: #A3A3A3;
+  --accent-color: #5E81AC;
+  --icon-color: #E0E0E0;
+  --image-border-color: #E0E0E0;
   --music-bg-start: #7aa2f7;
   --music-bg-end: #bb9af7;
   --music-vibe-start: #7dcfff;a
   --music-vibe-end: #f7768e;
   --panel-bg: rgba(0, 0, 0, 0.3);
-  --equation-bg: #2d2d2d;
-  --equation-text: #c0caf5;
+  --equation-bg: #1E1E1E;
+  --equation-text: #E0E0E0;
   --table-border-color: #3b3b3b;
-  --table-header-bg: #2d2d2d;
+  --table-header-bg: #1E1E1E;
   --table-row-alt-bg: rgba(255, 255, 255, 0.05);
 }
 
@@ -56,7 +59,8 @@ body {
   background-color: var(--background-color);
   color: var(--text-color);
   margin: 0;
-  font-family: 'Inter var', sans-serif;
+  font-family: "IBM Plex Sans", sans-serif;
+  line-height: 1.6;
 }
 
 .lead {
@@ -150,7 +154,7 @@ img:not(.float-right):not(.float-left) {
 .music-page {
   background: radial-gradient(circle at top left, #3a1c71, #1e1e1e);
   color: #eee;
-  font-family: sans-serif;
+  font-family: "IBM Plex Sans", sans-serif;
   margin: 0;
   height: 100vh;
   display: flex;
@@ -484,4 +488,50 @@ tbody tr:nth-child(odd) {
 
 .equation-box .katex-display {
   margin: 0;
+}
+
+/* ------------------------------------------------------
+   10) MINIMALISTIC LAYOUT
+   ------------------------------------------------------ */
+
+h1,
+h2,
+h3 {
+  font-family: "Inter", sans-serif;
+  color: var(--text-color);
+  margin-bottom: 20px;
+}
+
+.quick-overview {
+  background-color: var(--background-secondary);
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 32px;
+}
+
+.quick-overview li {
+  margin-bottom: 12px;
+}
+
+code {
+  font-family: "Roboto Mono", monospace;
+  background-color: var(--background-secondary);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+pre {
+  background-color: var(--background-secondary);
+  padding: 16px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.section {
+  padding-bottom: 32px;
+  border-bottom: 1px solid var(--background-secondary);
+}
+
+.section:last-child {
+  border-bottom: none;
 }

--- a/index.html
+++ b/index.html
@@ -31,12 +31,12 @@ static_theme: true
 </article>
 
 <!-- Section for Paper Summaries -->
-  <section>
+  <section class="section">
     <h2 id="summaries"><a href="/paper_summaries_field.html">Paper Summaries</a></h2>
   </section>
 
   <!-- Section for Revision notes -->
-  <section>
+  <section class="section">
     <h2 id="revision-notes">Revision notes</h2>
     <ul class="icon-list">
         {% assign rev_posts = site.categories["Revision Notes"] %}
@@ -53,7 +53,7 @@ static_theme: true
   </section>
 
   <!-- Section for AI generated reports -->
-  <section>
+  <section class="section">
     <details>
       <summary><h2 id="ml-deep">AI generated reports</h2></summary>
       <ul class="icon-list">


### PR DESCRIPTION
## Summary
- update dark theme variables for a minimal palette
- use IBM Plex Sans for body text and Inter for headings
- include Google Fonts link
- style sections, code blocks, and quick overview container
- wrap CS336 overview list in a styled div

## Testing Done
- `jekyll build`