### PR TITLE
[Fix] Override home page text color

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,6 +4,7 @@
     {% include head.html %}
   </head>
   <body
+    class="home-page"
     style="
       margin: 0;
       padding: 0;
@@ -18,6 +19,7 @@
       min-height: 100vh;
       color: #f0ead6;
       font-family: "IBM Plex Sans", sans-serif;
+      --text-color: #f0ead6;
     "
   >
     <button

--- a/css/override.css
+++ b/css/override.css
@@ -535,3 +535,22 @@ pre {
 .section:last-child {
   border-bottom: none;
 }
+
+/* ------------------------------------------------------
+   Home page overrides
+   ------------------------------------------------------ */
+
+.home-page {
+  --text-color: #f0ead6;
+  color: var(--text-color);
+}
+
+.home-page a,
+.home-page a:visited {
+  color: var(--text-color);
+}
+
+.home-page a:hover {
+  color: var(--text-color);
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- set home page `body` class and color variable for off-white text
- add CSS for `.home-page` to enforce off-white text and link colors

## Testing Done
- `jekyll build`
