### PR TITLE
[Fix] Theme-specific code borders

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -10,6 +10,7 @@
   --text-color: #000080;
   --icon-color: #000080;
   --image-border-color: #000000;
+  --code-border-color: #000000;
   --panel-bg: rgba(0, 0, 0, 0.3);
   --music-bg-start: #3b82f6;
   --music-bg-end: #0ea5e9;
@@ -25,6 +26,7 @@
   --text-color: #000080;
   --icon-color: #000080;
   --image-border-color: #000080;
+  --code-border-color: #000000;
   --panel-bg: rgba(5, 5, 5, 0.3);
   --table-border-color: #cccccc;
   --table-header-bg: #e8e8ff;
@@ -39,6 +41,7 @@
   --accent-color: #5E81AC;
   --icon-color: #E0E0E0;
   --image-border-color: #E0E0E0;
+  --code-border-color: #FFFFFF;
   --music-bg-start: #7aa2f7;
   --music-bg-end: #bb9af7;
   --music-vibe-start: #7dcfff;a
@@ -518,6 +521,7 @@ code {
   background-color: var(--background-secondary);
   padding: 4px 8px;
   border-radius: 4px;
+  border: 1px solid var(--code-border-color);
 }
 
 pre {


### PR DESCRIPTION
## Summary
- add theme variables for code borders
- draw borders around inline code using the new variable

## Testing Done
- `jekyll build`
