### PR TITLE
[Fix] Reduce code font size

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -522,7 +522,7 @@ code {
   padding: 4px 8px;
   border-radius: 4px;
   border: 1px solid var(--code-border-color);
-  font-size: 15px;
+  font-size: 13px;
 }
 
 pre {
@@ -530,7 +530,7 @@ pre {
   padding: 16px;
   border-radius: 8px;
   overflow-x: auto;
-  font-size: 15px;
+  font-size: 13px;
 }
 
 .section {


### PR DESCRIPTION
## Summary
Lowered the font size for `code` and `pre` elements from `15px` to `13px` in `override.css`.

## Testing Done
- `jekyll build`