### PR TITLE
[Fix] Update lecture 2 notes link

### DIFF
--- a/revision_notes.md
+++ b/revision_notes.md
@@ -9,5 +9,5 @@ title: Revision Notes
 This is probably the best intuition building language modeling course around. I'm sharing notes for each lecture here.
 
 ### Lesson 2
-[Lecture 2 notes](/revision%20notes/2025/05/15/cs336-revision-notes.html)
+[Lecture 2 notes]({{ '/revision%20notes/2025/05/15/cs336-revision-notes.html' | relative_url }})
 


### PR DESCRIPTION
Updated the URL on revision notes page to use Jekyll's `relative_url` filter.

### Testing Done
- `jekyll build`