### PR TITLE
[Fix] Add deep research link

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,9 @@ static_theme: true
     <h2 id="ml-deep"><a href="/ai_generated_reports.html">AI generated reports</a></h2>
     <p>This section links to AI generated reports.
       Think audio 🎧 summaries like
-      <a href="https://notebooklm.google.com">NotebookLM</a> or ChatGPT 🤖
-      <a href="/ai_generated_reports.html#deep-research-summaries">deep research docs</a>.
+      <a href="https://notebooklm.google.com">NotebookLM</a> or text summaries from
+      tools like 🤖 ChatGPT
+      <a href="https://openai.com/index/introducing-deep-research/">deep research</a>.
     </p>
     <ul class="icon-list">
       {% assign ml_posts = site.categories["Machine Learning Deep-Dives"] %}


### PR DESCRIPTION
## Summary
Added a hyperlink to OpenAI's Deep Research announcement in the AI generated reports section of `index.html`.

## Testing Done
- `jekyll build`
