### PR TITLE
[Fix] Show attention post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,3 +38,4 @@ exclude:
 
 paginate: 5
 paginate_path: "/page:num"
+future: true

--- a/_posts/2025-06-01-attention-mechanisms-demystified.md
+++ b/_posts/2025-06-01-attention-mechanisms-demystified.md
@@ -5,7 +5,7 @@ date: 2025-06-01 00:00:00 -0400
 categories: ["Ponderings"]
 ---
 
-## Attention Mechanisms Demystified: An Expert's Deep Dive into Q, K, V, and Self-Attention
+## 2025 – Attention Mechanisms Demystified: An Expert's Deep Dive into Q, K, V, and Self-Attention
 
 Attention mechanisms are a foundational innovation in modern machine learning, significantly enhancing models' capability to selectively process information relevant to their tasks. Originating in neural machine translation, attention provides a dynamic method for information aggregation, crucially influencing fields ranging from natural language processing (NLP) to computer vision. This post comprehensively elucidates the intricate mechanics of attention, clearly defining queries (Q), keys (K), and values (V), and progressively building from general attention to self- and cross-attention.
 


### PR DESCRIPTION
## Summary
- set `future: true` so Jekyll builds posts dated in the future
- include the year in the attention deep-dive heading

## Testing Done
- `jekyll build`