### PR TITLE
[Fix] Contact panel overlays content on mobile

### DIFF
--- a/css/override.css
+++ b/css/override.css
@@ -449,9 +449,12 @@ a:visited {
     margin: 1rem;
   }
   .links-panel {
-    left: 10px;
-    right: 10px;
+    position: static;
+    left: auto;
+    right: auto;
     width: auto;
+    margin-top: 1rem;
+    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust `.links-panel` positioning for small screens

## Testing Done
- `jekyll build`
