### PR TITLE
[Fix] Link CS336 lecture 3 on course page

### DIFF
--- a/_posts/2025-05-22-cs336-lecture-3.md
+++ b/_posts/2025-05-22-cs336-lecture-3.md
@@ -1,0 +1,68 @@
+---
+layout: content
+title: "Lecture 3"
+date: 2025-05-22 00:00:00 -0400
+categories: ["Revision Notes"]
+---
+
+# CS336 Lecture 3 — LLM Architecture & Training Stability
+
+*Revision notes updated May 24 2025*
+
+---
+
+## Quick Overview
+
+This lecture surveys architectural choices in modern large language models and explores techniques that stabilize training. It contrasts earlier Transformer variants with lessons from recent LLMs.
+
+---
+
+## Normalization Techniques
+
+- RMSNorm has largely replaced LayerNorm thanks to lower memory use and similar performance. It omits mean adjustment and bias terms.
+- Pre-norm application before each block improves gradient flow and prevents loss spikes. Some models place an extra norm after the block as well.
+- Bias terms are often removed from linear layers, which empirically helps large networks train more reliably.
+
+## Activation Functions and MLPs
+
+- Modern models favor gated linear units such as SwiGLU or GeGLU over ReLU or GELU.
+- GLUs gate the first linear layer's output elementwise, consistently outperforming non-gated activations.
+
+## Serial vs. Parallel Layers
+
+- Most architectures keep the classic attention-then-MLP order. A few compute them in parallel for GPU efficiency, but serial layers remain more expressive.
+
+## Position Embeddings
+
+- Rotary Position Embeddings (RoPE) have become standard. They rotate queries and keys within the attention module to encode relative positions.
+
+## Hyperparameter Guidelines
+
+- Feed-forward dimensions scale to four times the model width for non-GLU MLPs or roughly eight-thirds times width with GLUs.
+- Set the head dimension so that model dimension equals head dimension times the number of heads.
+- A hidden-to-layer ratio around 128 provides a good balance of width and depth.
+- Vocabulary sizes have grown to the 100k–250k range, especially for multilingual models.
+- Weight decay remains useful in pre-training, whereas dropout is less common.
+
+## Training Stability Tricks
+
+- Z-loss penalizes deviations of the softmax normalizer from one to avoid numerical issues.
+- Applying LayerNorm to queries and keys (QK Norm) bounds softmax inputs, preventing gradient spikes.
+
+## Attention Variations for Inference
+
+- Multi-Query (MQA) and Grouped-Query Attention (GQA) reduce key/value cache size by sharing keys and values across heads, greatly speeding generation.
+
+## Long Context Handling
+
+- Models mix full self-attention without positions for periodic global context and sliding-window attention with RoPE for local detail.
+
+## Source
+
+Percy Liang, **CS336 — Large Language Models**, Stanford University, Lecture 3: *Architecture* (Winter 2025).
+
+## Slides & Recording
+
+- [Recording](https://www.youtube.com/watch?v=ptFiH_bHnJw)
+- [Slides](https://github.com/stanford-cs336/spring2024-lectures/blob/main/nonexecutable/Lecture%203%20-%20architecture.pdf)
+

--- a/revision_notes.md
+++ b/revision_notes.md
@@ -12,3 +12,6 @@ This is probably the best intuition building language modeling course around. I'
   [YouTube](https://www.youtube.com/watch?v=dQw4w9WgXcQ) /
   [Course material](https://stanford-cs336.github.io/spring2025/lectures/2)
 
+- Lesson 3 – [My notes]({{ '/revision%20notes/2025/05/22/cs336-lecture-3.html' | relative_url }}) /
+  [YouTube](https://www.youtube.com/watch?v=ptFiH_bHnJw) /
+  [Slides](https://github.com/stanford-cs336/spring2024-lectures/blob/main/nonexecutable/Lecture%203%20-%20architecture.pdf)


### PR DESCRIPTION
## Summary
- add CS336 lecture 3 entry with links to notes, video, and slides

## Testing Done
- `jekyll build`
